### PR TITLE
Rename .jar to well known name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,4 @@ target/
 dependency-reduced-pom.xml
 /functions-coffee-order-demo/src/main/functions/functions-coffee-order.jar
 /functions-coffee-order-demo/src/main/arduino/.build/
+.pkg/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,8 @@ install:
 
 build_script:
   - mvn clean install -DskipTests
+  - ps: mkdir .pkg
+  - ps: Get-ChildItem -Path .\azure-functions-java-worker\target\* -Include 'azure*' -Exclude '*shaded.jar' | %{ Copy-Item $_.FullName .\.pkg\azure-functions-java-worker.jar }
   - ps: nuget pack ./tools/AzureFunctionsJavaWorker.nuspec -Properties versionsuffix=$env:APPVEYOR_BUILD_NUMBER
 
 artifacts:

--- a/tools/AzureFunctionsJavaWorker.nuspec
+++ b/tools/AzureFunctionsJavaWorker.nuspec
@@ -14,10 +14,10 @@
     <description>Microsoft Azure Functions Java Worker</description>
     <copyright>Copyright (c) Microsoft Corporation. All rights reserved.</copyright>
     <contentFiles>
-      <files include="..\azure-functions-java-worker\target\azure-functions-java-worker-*.jar" exclude="..\azure-functions-java-worker\target\*-shaded.jar" buildAction="None" copyToOutput="true" flatten="false"/>
+      <files include="**/*" buildAction="None" copyToOutput="true" flatten="false"/>
     </contentFiles>
   </metadata>
   <files>
-    <file src="..\azure-functions-java-worker\target\azure-functions-java-worker-*.jar" exclude="..\azure-functions-java-worker\target\*-shaded.jar" target="contentFiles/any/any/workers/java" />
+    <file src="..\.pkg\**" target="contentFiles/any/any/workers/java" />
   </files>
 </package>

--- a/tools/devdoc.md
+++ b/tools/devdoc.md
@@ -12,8 +12,10 @@ CI runs on every PR and nightly on `dev` and `master`
 
 To produce the build results locally, be sure you have Java, Maven, and NuGet installed.
 
-```
+```powershell
 mvn clean install -DskipTests
+mkdir .pkg
+Get-ChildItem -Path .\azure-functions-java-worker\target\* -Include 'azure*' -Exclude '*shaded.jar' | %{ Copy-Item $_.FullName .\.pkg\azure-functions-java-worker.jar }
 nuget pack ./tools/AzureFunctionsJavaWorker.nuspec -Properties versionsuffix=LOCAL
 ```
 


### PR DESCRIPTION
The script host project expects the java-worker to be a well known name, so need to update the script to rename the jar.