### PR TITLE
Add explicit dependency on javax.annotation to support compilation on…

### DIFF
--- a/azure-functions-java-worker/pom.xml
+++ b/azure-functions-java-worker/pom.xml
@@ -96,6 +96,11 @@
       <artifactId>jackson-annotations</artifactId>
       <version>2.9.2</version>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.1</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Add explicit dependency on javax.annotation to support compilation on JDK 8 and JDK 9 (without this, compilation fails under JDK 9 due to these annotations not being available by default under JDK 9.