### PR TITLE
Handle exceptions coming from function invocation

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodInvokeInfo.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodInvokeInfo.java
@@ -20,23 +20,8 @@ class JavaMethodInvokeInfo {
         Object instance = Modifier.isStatic(this.m.getModifiers()) ? null : instanceSupplier.get();
         try {
             return this.m.invoke(instance, this.args);
-        } catch (InvocationTargetException ex) {
-            if (ex.getCause() == null) {
-                return ExceptionUtils.rethrow(ex);
-            }
-            Throwable userModeEx = ex.getCause();
-            StackTraceElement[] parentStackTraces = ex.getStackTrace();
-            StackTraceElement[] userStackTraces = userModeEx.getStackTrace();
-            int lastUserModeStackFrame = userStackTraces.length - 1;
-            if (lastUserModeStackFrame > parentStackTraces.length - 1) {
-                for (int parentFrame = parentStackTraces.length - 1; parentFrame >= 0; parentFrame--, lastUserModeStackFrame--) {
-                    if (!parentStackTraces[parentFrame].equals(userStackTraces[lastUserModeStackFrame])) {
-                        break;
-                    }
-                }
-            }
-            userModeEx.setStackTrace(Arrays.copyOf(userStackTraces, lastUserModeStackFrame + 1));
-            return ExceptionUtils.rethrow(userModeEx);
+        } catch (Exception ex) {
+            return ExceptionUtils.rethrow(ex);
         }
     }
 

--- a/src/main/java/com/microsoft/azure/functions/worker/handler/MessageHandler.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/handler/MessageHandler.java
@@ -48,8 +48,8 @@ public abstract class MessageHandler<TRequest extends Message, TResponse extends
             }
         } catch (Exception ex) {
             status = StatusResult.Status.Failure;
-            statusMessage = ex.getMessage();
-            rpcException = RpcException.newBuilder().setMessage(ex.getMessage()).setStackTrace(ExceptionUtils.getStackTrace(ex)).build();
+            statusMessage = ExceptionUtils.getRootCauseMessage(ex);
+            rpcException = RpcException.newBuilder().setMessage(statusMessage).setStackTrace(ExceptionUtils.getStackTrace(ex)).build();
             this.getLogger().log(Level.SEVERE, statusMessage, ex);
         }
         if (this.responseStatusMarshaller != null) {


### PR DESCRIPTION
Fixes #166 
[ExceptionUtils.getRootCause](https://commons.apache.org/proper/commons-lang/javadocs/api-3.4/org/apache/commons/lang3/exception/ExceptionUtils.html#getRootCause(java.lang.Throwable)) to handle function invocation exceptions