### PR TITLE
Add support to bind to String[]

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,6 @@ install:
   - cmd: mvn -v
   - ps: Get-Command nuget
   - cmd: echo %JAVA_HOME%
-  - cmd: dotnet --info
   
 build_script:
   - cmd: mvn clean package -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B
@@ -81,8 +80,8 @@ after_build:
       cd -Path c:\projects\azure-functions-java-worker
 
       Write-Host "Copying EventHubs function.json as temporary workaround...."
-      Copy-Item ".\endtoendtests\functionInputJson.json" "c:\projects\azure-functions-java-worker\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputJSON"
-      Copy-Item ".\endtoendtests\functionInputString.json" "c:\projects\azure-functions-java-worker\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputString"
+      Copy-Item ".\endtoendtests\functionInputJson.json" "c:\projects\azure-functions-java-worker\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputJSON\function.json"
+      Copy-Item ".\endtoendtests\functionInputString.json" "c:\projects\azure-functions-java-worker\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputString\function.json"
 
       $proc = start-process -filepath c:\projects\azure-functions-java-worker\Azure.Functions.Cli\func.exe -WorkingDirectory "c:\projects\azure-functions-java-worker\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests" -ArgumentList "host start" -PassThru
       # wait for host to start

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,8 +81,8 @@ after_build:
       cd -Path c:\projects\azure-functions-java-worker
 
       Write-Host "Copying EventHubs function.json as temporary workaround...."
-      Copy-Item ".\endtoendtests\functionInputJson.json" "c:\projects\azure-functions-java-worker\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutput\function.json"
-      Copy-Item ".\endtoendtests\functionInputString.json" "c:\projects\azure-functions-java-worker\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutput\function.json"
+      Copy-Item ".\endtoendtests\functionInputJson.json" "c:\projects\azure-functions-java-worker\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputJSON"
+      Copy-Item ".\endtoendtests\functionInputString.json" "c:\projects\azure-functions-java-worker\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputString"
 
       $proc = start-process -filepath c:\projects\azure-functions-java-worker\Azure.Functions.Cli\func.exe -WorkingDirectory "c:\projects\azure-functions-java-worker\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests" -ArgumentList "host start" -PassThru
       # wait for host to start

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,7 +81,8 @@ after_build:
       cd -Path c:\projects\azure-functions-java-worker
 
       Write-Host "Copying EventHubs function.json as temporary workaround...."
-      Copy-Item ".\endtoendtests\function.json" "c:\projects\azure-functions-java-worker\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutput"
+      Copy-Item ".\endtoendtests\functionInputJson.json" "c:\projects\azure-functions-java-worker\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutput\function.json"
+      Copy-Item ".\endtoendtests\functionInputString.json" "c:\projects\azure-functions-java-worker\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutput\function.json"
 
       $proc = start-process -filepath c:\projects\azure-functions-java-worker\Azure.Functions.Cli\func.exe -WorkingDirectory "c:\projects\azure-functions-java-worker\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests" -ArgumentList "host start" -PassThru
       # wait for host to start

--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Constants.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Constants.cs
@@ -30,6 +30,8 @@ namespace Azure.Functions.Java.Tests.E2E
         // EventHubs
         public static string OutputEventHubQueueName = "test-eventhuboutput-java";
         public static string InputEventHubName = "test-input-java";
+        public static string InputJsonEventHubName = "test-inputjson-java";
+        public static string InputCardinalityOneEventHubName = "test-inputOne-java";
         public static string EventHubsConnectionStringSetting = Environment.GetEnvironmentVariable("AzureWebJobsEventHubSender");
     }
 }

--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Constants.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Constants.cs
@@ -30,7 +30,9 @@ namespace Azure.Functions.Java.Tests.E2E
         // EventHubs
         public static string OutputEventHubQueueName = "test-eventhuboutput-java";
         public static string InputEventHubName = "test-input-java";
+        public static string OutputJsonEventHubQueueName = "test-eventhuboutputjson-java";
         public static string InputJsonEventHubName = "test-inputjson-java";
+        public static string OutputOneEventHubQueueName = "test-eventhuboutputone-java";
         public static string InputCardinalityOneEventHubName = "test-inputOne-java";
         public static string EventHubsConnectionStringSetting = Environment.GetEnvironmentVariable("AzureWebJobsEventHubSender");
     }

--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/CosmosDBEndToEndTests.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/CosmosDBEndToEndTests.cs
@@ -1,11 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Newtonsoft.Json.Linq;
 using System;
 using System.Net;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/CosmosDBHelpers.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/CosmosDBHelpers.cs
@@ -2,12 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
-using System.Net;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
-using Newtonsoft.Json;
 
 namespace Azure.Functions.Java.Tests.E2E
 {

--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/EventHubsEndToEndTests.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/EventHubsEndToEndTests.cs
@@ -3,6 +3,8 @@
 
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -14,20 +16,15 @@ namespace Azure.Functions.Java.Tests.E2E
     public class EventHubsEndToEndTests 
     {
         [Fact]
-        public async Task EventHubTriggerAndOutput_Succeeds()
+        public async Task EventHubTriggerAndOutputJSON_Succeeds()
         {
             string expectedEventId = Guid.NewGuid().ToString();
             try
             {
-                //Setup
-                // Need to setup EventHubs: test-input-java and test-output-java
-                await EventHubsHelpers.SendMessagesAsync(expectedEventId);
+                await SetupQueue();
 
-                //Clear queue
-                await StorageHelpers.ClearQueue(Constants.OutputEventHubQueueName);
-
-                //Set up and trigger            
-                await StorageHelpers.CreateQueue(Constants.OutputEventHubQueueName);
+                // Need to setup EventHubs: test-inputjson-java and test-output-java
+                await EventHubsHelpers.SendJSONMessagesAsync(expectedEventId);
 
                 //Verify
                 var queueMessage = await StorageHelpers.ReadFromQueue(Constants.OutputEventHubQueueName);
@@ -38,6 +35,59 @@ namespace Azure.Functions.Java.Tests.E2E
                 //Clear queue
                 await StorageHelpers.ClearQueue(Constants.OutputEventHubQueueName);
             }
+        }
+
+        [Fact]
+        public async Task EventHubTriggerAndOutputString_Succeeds()
+        {
+            string expectedEventId = Guid.NewGuid().ToString();
+            try
+            {
+                await SetupQueue();
+
+                // Need to setup EventHubs: test-input-java and test-output-java
+                await EventHubsHelpers.SendMessagesAsync(expectedEventId);
+
+                //Verify
+                var queueMessage = await StorageHelpers.ReadFromQueue(Constants.OutputEventHubQueueName);
+                Assert.Contains(expectedEventId, queueMessage);
+            }
+            finally
+            {
+                //Clear queue
+                await StorageHelpers.ClearQueue(Constants.OutputEventHubQueueName);
+            }
+        }
+
+        [Fact]
+        public async Task EventHubTriggerCardinalityOne_Succeeds()
+        {
+            string expectedEventId = Guid.NewGuid().ToString();
+            try
+            {
+                await SetupQueue();
+
+                // Need to setup EventHubs: test-inputOne-java and test-output-java
+                await EventHubsHelpers.SendMessagesAsync(expectedEventId);
+
+                //Verify
+                IEnumerable<string> queueMessages = await StorageHelpers.ReadMessagesFromQueue(Constants.OutputEventHubQueueName);
+                Assert.True(queueMessages.All(msg => msg.Contains(expectedEventId)));
+            }
+            finally
+            {
+                //Clear queue
+                await StorageHelpers.ClearQueue(Constants.OutputEventHubQueueName);
+            }
+        }
+
+        private static async Task SetupQueue()
+        {
+            //Clear queue
+            await StorageHelpers.ClearQueue(Constants.OutputEventHubQueueName);
+
+            //Set up and trigger            
+            await StorageHelpers.CreateQueue(Constants.OutputEventHubQueueName);
         }
     }
 }

--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/EventHubsEndToEndTests.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/EventHubsEndToEndTests.cs
@@ -20,7 +20,7 @@ namespace Azure.Functions.Java.Tests.E2E
             {
                 await SetupQueue(Constants.OutputJsonEventHubQueueName);
 
-                // Need to setup EventHubs: test-inputjson-java and test-output-java
+                // Need to setup EventHubs: test-inputjson-java and test-outputjson-java
                 await EventHubsHelpers.SendJSONMessagesAsync(expectedEventId);
 
                 //Verify
@@ -65,11 +65,11 @@ namespace Azure.Functions.Java.Tests.E2E
             {
                 await SetupQueue(Constants.OutputOneEventHubQueueName);
 
-                // Need to setup EventHubs: test-inputOne-java and test-output-java
+                // Need to setup EventHubs: test-inputOne-java and test-outputone-java
                 await EventHubsHelpers.SendMessagesAsync(expectedEventId, Constants.InputCardinalityOneEventHubName);
 
                 //Verify
-                IEnumerable<string> queueMessages = await StorageHelpers.ReadMessagesFromQueue(Constants.OutputEventHubQueueName);
+                IEnumerable<string> queueMessages = await StorageHelpers.ReadMessagesFromQueue(Constants.OutputOneEventHubQueueName);
                 Assert.True(queueMessages.All(msg => msg.Contains(expectedEventId)));
             }
             finally

--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/EventHubsHelpers.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/EventHubsHelpers.cs
@@ -10,7 +10,7 @@ namespace Azure.Functions.Java.Tests.E2E
 {
     public class EventHubsHelpers
     {
-        public static async Task SendMessagesAsync(string eventId)
+        public static async Task SendJSONMessagesAsync(string eventId)
         {
             // write 3 events
             List<EventData> events = new List<EventData>();
@@ -28,7 +28,26 @@ namespace Azure.Functions.Java.Tests.E2E
             }
 
             EventHubsConnectionStringBuilder builder = new EventHubsConnectionStringBuilder(Constants.EventHubsConnectionStringSetting);
-            builder.EntityPath = Constants.InputEventHubName;
+            builder.EntityPath = Constants.InputJsonEventHubName;
+            EventHubClient eventHubClient = EventHubClient.CreateFromConnectionString(builder.ToString());
+            await eventHubClient.SendAsync(events);
+        }
+
+        public static async Task SendMessagesAsync(string eventId)
+        {
+            // write 3 events
+            List<EventData> events = new List<EventData>();
+            string[] ids = new string[3];
+            for (int i = 0; i < 3; i++)
+            {
+                ids[i] = eventId + $"TestEvent{i}";
+                var evt = new EventData(Encoding.UTF8.GetBytes(ids[i]));
+                evt.Properties.Add("TestIndex", i);
+                events.Add(evt);
+            }
+
+            EventHubsConnectionStringBuilder builder = new EventHubsConnectionStringBuilder(Constants.EventHubsConnectionStringSetting);
+            builder.EntityPath = Constants.InputCardinalityOneEventHubName;
             EventHubClient eventHubClient = EventHubClient.CreateFromConnectionString(builder.ToString());
             await eventHubClient.SendAsync(events);
         }

--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/EventHubsHelpers.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/EventHubsHelpers.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.Azure.EventHubs;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.EventHubs;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -33,7 +35,7 @@ namespace Azure.Functions.Java.Tests.E2E
             await eventHubClient.SendAsync(events);
         }
 
-        public static async Task SendMessagesAsync(string eventId)
+        public static async Task SendMessagesAsync(string eventId, string evenHubName)
         {
             // write 3 events
             List<EventData> events = new List<EventData>();
@@ -47,7 +49,7 @@ namespace Azure.Functions.Java.Tests.E2E
             }
 
             EventHubsConnectionStringBuilder builder = new EventHubsConnectionStringBuilder(Constants.EventHubsConnectionStringSetting);
-            builder.EntityPath = Constants.InputCardinalityOneEventHubName;
+            builder.EntityPath = evenHubName;
             EventHubClient eventHubClient = EventHubClient.CreateFromConnectionString(builder.ToString());
             await eventHubClient.SendAsync(events);
         }

--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/StorageHelpers.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/StorageHelpers.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Queue;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Azure.Functions.Java.Tests.E2E
@@ -52,6 +53,24 @@ namespace Azure.Functions.Java.Tests.E2E
             });
             await queue.DeleteMessageAsync(retrievedMessage);
             return retrievedMessage.AsString;
+        }
+
+        public async static Task<IEnumerable<string>> ReadMessagesFromQueue(string queueName)
+        {
+            CloudQueue queue = _queueClient.GetQueueReference(queueName);
+            IEnumerable<CloudQueueMessage> retrievedMessages = null;
+            List<string> messages = new List<string>();
+            await Utilities.RetryAsync(async () =>
+            {
+                retrievedMessages = await queue.GetMessagesAsync(3);
+                return retrievedMessages != null;
+            });
+            foreach(CloudQueueMessage msg in retrievedMessages)
+            {
+                messages.Add(msg.AsString);
+                await queue.DeleteMessageAsync(msg);
+            }
+            return messages;
         }
     }
 }

--- a/endtoendtests/functionInputJson.json
+++ b/endtoendtests/functionInputJson.json
@@ -1,14 +1,14 @@
 {
   "scriptFile" : "..\\azure-functions-java-endtoendtests-1.0-SNAPSHOT.jar",
-  "entryPoint" : "com.microsoft.azure.functions.endtoendtests.EventHubTriggerTests.EventHubTriggerAndOutput",
+  "entryPoint" : "com.microsoft.azure.functions.endtoendtests.EventHubTriggerTests.EventHubTriggerAndOutputJSON",
   "bindings" : [ {
     "type" : "eventHubTrigger",
     "name" : "messages",
     "direction" : "in",
-    "consumerGroup" : "$Default",
 	"cardinality": "many",
+    "consumerGroup" : "$Default",
     "connection" : "AzureWebJobsEventHubSender",
-    "eventHubName" : "test-input-java"
+    "eventHubName" : "test-inputjson-java"
   }, {
     "type" : "eventHub",
     "name" : "output",

--- a/endtoendtests/functionInputJson.json
+++ b/endtoendtests/functionInputJson.json
@@ -5,8 +5,8 @@
     "type" : "eventHubTrigger",
     "name" : "messages",
     "direction" : "in",
-	"cardinality": "many",
     "consumerGroup" : "$Default",
+	"cardinality" : "many",
     "connection" : "AzureWebJobsEventHubSender",
     "eventHubName" : "test-inputjson-java"
   }, {

--- a/endtoendtests/functionInputJson.json
+++ b/endtoendtests/functionInputJson.json
@@ -5,8 +5,8 @@
     "type" : "eventHubTrigger",
     "name" : "messages",
     "direction" : "in",
-    "consumerGroup" : "$Default",
 	"cardinality" : "many",
+    "consumerGroup" : "$Default",
     "connection" : "AzureWebJobsEventHubSender",
     "eventHubName" : "test-inputjson-java"
   }, {
@@ -14,7 +14,7 @@
     "name" : "output",
     "direction" : "out",
     "connection" : "AzureWebJobsEventHubSender",
-    "eventHubName" : "test-output-java"
+    "eventHubName" : "test-outputjson-java"
   } ],
   "disabled" : false
 }

--- a/endtoendtests/functionInputString.json
+++ b/endtoendtests/functionInputString.json
@@ -6,8 +6,8 @@
     "name" : "messages",
     "direction" : "in",
     "dataType" : "string",
-	"cardinality" : "many",
     "consumerGroup" : "$Default",
+	"cardinality" : "many",
     "connection" : "AzureWebJobsEventHubSender",
     "eventHubName" : "test-input-java"
   }, {

--- a/endtoendtests/functionInputString.json
+++ b/endtoendtests/functionInputString.json
@@ -1,0 +1,21 @@
+{
+  "scriptFile" : "..\\azure-functions-java-endtoendtests-1.0-SNAPSHOT.jar",
+  "entryPoint" : "com.microsoft.azure.functions.endtoendtests.EventHubTriggerTests.EventHubTriggerAndOutputString",
+  "bindings" : [ {
+    "type" : "eventHubTrigger",
+    "name" : "messages",
+    "direction" : "in",
+    "dataType" : "string",
+	"cardinality": "many",
+    "consumerGroup" : "$Default",
+    "connection" : "AzureWebJobsEventHubSender",
+    "eventHubName" : "test-input-java"
+  }, {
+    "type" : "eventHub",
+    "name" : "output",
+    "direction" : "out",
+    "connection" : "AzureWebJobsEventHubSender",
+    "eventHubName" : "test-output-java"
+  } ],
+  "disabled" : false
+}

--- a/endtoendtests/functionInputString.json
+++ b/endtoendtests/functionInputString.json
@@ -6,7 +6,7 @@
     "name" : "messages",
     "direction" : "in",
     "dataType" : "string",
-	"cardinality": "many",
+	"cardinality" : "many",
     "consumerGroup" : "$Default",
     "connection" : "AzureWebJobsEventHubSender",
     "eventHubName" : "test-input-java"

--- a/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/CosmosDBTriggerTests.java
+++ b/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/CosmosDBTriggerTests.java
@@ -22,14 +22,15 @@ public class CosmosDBTriggerTests {
             HttpMethod.POST }, authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<String>> request,
             @CosmosDBInput(name = "item", databaseName = "%CosmosDBDatabaseName%", collectionName = "ItemsCollectionIn", connectionStringSetting = "AzureWebJobsCosmosDBConnectionString", id = "{docId}") String item,
             final ExecutionContext context) {
-        
-            context.getLogger().info("Java HTTP trigger processed a request."); 
-         
-            if (item!= null) {
-                return request.createResponseBuilder(HttpStatus.OK).body("Received Document" + item).build();
-            } else {
-                return request.createResponseBuilder(HttpStatus.INTERNAL_SERVER_ERROR).body("Did not find expected item in ItemsCollectionIn").build();
-            }
+
+        context.getLogger().info("Java HTTP trigger processed a request.");
+
+        if (item != null) {
+            return request.createResponseBuilder(HttpStatus.OK).body("Received Document" + item).build();
+        } else {
+            return request.createResponseBuilder(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Did not find expected item in ItemsCollectionIn").build();
+        }
     }
 
     @FunctionName("CosmosDBInputIdPOJO")
@@ -37,14 +38,15 @@ public class CosmosDBTriggerTests {
             HttpMethod.POST }, authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<String>> request,
             @CosmosDBInput(name = "item", databaseName = "%CosmosDBDatabaseName%", collectionName = "ItemsCollectionIn", connectionStringSetting = "AzureWebJobsCosmosDBConnectionString", id = "{docId}") Document item,
             final ExecutionContext context) {
-        
-            context.getLogger().info("Java HTTP trigger processed a request."); 
-         
-            if (item!= null) {
-                return request.createResponseBuilder(HttpStatus.OK).body("Received Document with Id " + item.id).build();
-            } else {
-                return request.createResponseBuilder(HttpStatus.INTERNAL_SERVER_ERROR).body("Did not find expected item in ItemsCollectionIn").build();
-            }
+
+        context.getLogger().info("Java HTTP trigger processed a request.");
+
+        if (item != null) {
+            return request.createResponseBuilder(HttpStatus.OK).body("Received Document with Id " + item.id).build();
+        } else {
+            return request.createResponseBuilder(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Did not find expected item in ItemsCollectionIn").build();
+        }
     }
 
     /**
@@ -52,6 +54,25 @@ public class CosmosDBTriggerTests {
      * /api/CosmosDBInputQuery?name=joe Receives input with list of items matching
      * the sqlQuery
      */
+    @FunctionName("CosmosDBInputQueryPOJOArray")
+    public HttpResponseMessage CosmosDBInputQueryPOJOArray(@HttpTrigger(name = "req", methods = { HttpMethod.GET,
+            HttpMethod.POST }, authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<String>> request,
+            @CosmosDBInput(name = "item", databaseName = "%CosmosDBDatabaseName%", collectionName = "ItemsCollectionIn", connectionStringSetting = "AzureWebJobsCosmosDBConnectionString", sqlQuery = "SELECT f.id, f.name FROM f WHERE f.name = {name}") Document[] items,
+            final ExecutionContext context) {
+        context.getLogger().info("Java HTTP trigger processed a request.");
+
+        // Parse query parameters
+        String query = request.getQueryParameters().get("name");
+        String name = request.getBody().orElse(query);
+
+        if (items.length >= 2) {
+            return request.createResponseBuilder(HttpStatus.OK).body("Hello, " + name).build();
+        } else {
+            return request.createResponseBuilder(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body("Did not find expected items in CosmosDB input list").build();
+        }
+    }
+
     @FunctionName("CosmosDBInputQuery")
     public HttpResponseMessage CosmosDBInputQuery(@HttpTrigger(name = "req", methods = { HttpMethod.GET,
             HttpMethod.POST }, authLevel = AuthorizationLevel.ANONYMOUS) HttpRequestMessage<Optional<String>> request,
@@ -76,8 +97,8 @@ public class CosmosDBTriggerTests {
      * http://localhost:7071/api/CosmosDBOutput. A new document will add to the
      * collection.
      */
-    @FunctionName("cosmosTriggerAndOutput")
-    public void cosmosTriggerAndOutput(
+    @FunctionName("CosmosTriggerAndOutput")
+    public void CosmosTriggerAndOutput(
             @CosmosDBTrigger(name = "itemIn", databaseName = "%CosmosDBDatabaseName%", collectionName = "ItemCollectionIn", leaseCollectionName = "leases", connectionStringSetting = "AzureWebJobsCosmosDBConnectionString", createLeaseCollectionIfNotExists = true) Object inputItem,
             @CosmosDBOutput(name = "itemOut", databaseName = "%CosmosDBDatabaseName%", collectionName = "ItemCollectionOut", connectionStringSetting = "AzureWebJobsCosmosDBConnectionString") OutputBinding<Document> outPutItem,
             final ExecutionContext context) {

--- a/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/EventHubTriggerTests.java
+++ b/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/EventHubTriggerTests.java
@@ -14,7 +14,7 @@ public class EventHubTriggerTests {
     @FunctionName("EventHubTriggerAndOutputJSON")
     public void EventHubTriggerAndOutputJSON(
         @EventHubTrigger(name = "messages", eventHubName = "test-inputjson-java", connection = "AzureWebJobsEventHubSender") List<String> messages,
-        @EventHubOutput(name = "output", eventHubName = "test-output-java", connection = "AzureWebJobsEventHubSender") OutputBinding<String> output,
+        @EventHubOutput(name = "output", eventHubName = "test-outputjson-java", connection = "AzureWebJobsEventHubSender") OutputBinding<String> output,
         final ExecutionContext context
     ) {
         context.getLogger().info("Java Event Hub trigger received " + messages.size() +" messages");
@@ -34,7 +34,7 @@ public class EventHubTriggerTests {
     @FunctionName("EventHubTriggerCardinalityOne")
     public void EventHubTriggerCardinalityOne(
         @EventHubTrigger(name = "message", eventHubName = "test-inputOne-java", connection = "AzureWebJobsEventHubSender", dataType = "string") String message,
-        @EventHubOutput(name = "output", eventHubName = "test-output-java", connection = "AzureWebJobsEventHubSender") OutputBinding<String> output,
+        @EventHubOutput(name = "output", eventHubName = "test-outputone-java", connection = "AzureWebJobsEventHubSender") OutputBinding<String> output,
         final ExecutionContext context
     ) {
         context.getLogger().info("Java Event Hub trigger received message" + message);
@@ -44,10 +44,30 @@ public class EventHubTriggerTests {
     /**
      * This function verifies the above functions
      */
+    @FunctionName("TestEventHubOutputJson")
+    public void TestEventHubOutputJson(
+        @EventHubTrigger(name = "message", eventHubName = "test-outputjson-java", connection = "AzureWebJobsEventHubSender") String message,
+        @QueueOutput(name = "output", queueName = "test-eventhuboutputjson-java", connection = "AzureWebJobsStorage") OutputBinding<String> output,
+        final ExecutionContext context
+    ) {
+        context.getLogger().info("Java Event Hub Output function processed a message: " + message);
+        output.setValue(message);
+    }
+
     @FunctionName("TestEventHubOutput")
     public void TestEventHubOutput(
         @EventHubTrigger(name = "message", eventHubName = "test-output-java", connection = "AzureWebJobsEventHubSender") String message,
         @QueueOutput(name = "output", queueName = "test-eventhuboutput-java", connection = "AzureWebJobsStorage") OutputBinding<String> output,
+        final ExecutionContext context
+    ) {
+        context.getLogger().info("Java Event Hub Output function processed a message: " + message);
+        output.setValue(message);
+    }
+
+    @FunctionName("TestEventHubOutputInputOne")
+    public void TestEventHubOutputInputOne(
+        @EventHubTrigger(name = "message", eventHubName = "test-outputone-java", connection = "AzureWebJobsEventHubSender") String message,
+        @QueueOutput(name = "output", queueName = "test-eventhuboutputone-java", connection = "AzureWebJobsStorage") OutputBinding<String> output,
         final ExecutionContext context
     ) {
         context.getLogger().info("Java Event Hub Output function processed a message: " + message);

--- a/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/EventHubTriggerTests.java
+++ b/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/EventHubTriggerTests.java
@@ -11,9 +11,9 @@ public class EventHubTriggerTests {
     /**
      * This function will be invoked when a new message is received at the specified EventHub. The message contents are provided as input to this function.
      */
-    @FunctionName("EventHubTriggerAndOutput")
-    public void EventHubTriggerAndOutput(
-        @EventHubTrigger(name = "messages", eventHubName = "test-input-java", connection = "AzureWebJobsEventHubSender") List<String> messages,
+    @FunctionName("EventHubTriggerAndOutputJSON")
+    public void EventHubTriggerAndOutputJSON(
+        @EventHubTrigger(name = "messages", eventHubName = "test-inputjson-java", connection = "AzureWebJobsEventHubSender") List<String> messages,
         @EventHubOutput(name = "output", eventHubName = "test-output-java", connection = "AzureWebJobsEventHubSender") OutputBinding<String> output,
         final ExecutionContext context
     ) {
@@ -21,8 +21,28 @@ public class EventHubTriggerTests {
         output.setValue(messages.get(0));
     }
 
+    @FunctionName("EventHubTriggerAndOutputString")
+    public void EventHubTriggerAndOutputString(
+        @EventHubTrigger(name = "messages", eventHubName = "test-input-java", connection = "AzureWebJobsEventHubSender", dataType = "string") String[] messages,
+        @EventHubOutput(name = "output", eventHubName = "test-output-java", connection = "AzureWebJobsEventHubSender") OutputBinding<String> output,
+        final ExecutionContext context
+    ) {
+        context.getLogger().info("Java Event Hub trigger received " + messages.length +" messages");
+        output.setValue(messages[0]);
+    }
+
+    @FunctionName("EventHubTriggerCardinalityOne")
+    public void EventHubTriggerCardinalityOne(
+        @EventHubTrigger(name = "message", eventHubName = "test-inputOne-java", connection = "AzureWebJobsEventHubSender", dataType = "string") String message,
+        @EventHubOutput(name = "output", eventHubName = "test-output-java", connection = "AzureWebJobsEventHubSender") OutputBinding<String> output,
+        final ExecutionContext context
+    ) {
+        context.getLogger().info("Java Event Hub trigger received message" + message);
+        output.setValue(message);
+    }
+
     /**
-     * This function verifies the above
+     * This function verifies the above functions
      */
     @FunctionName("TestEventHubOutput")
     public void TestEventHubOutput(
@@ -33,4 +53,6 @@ public class EventHubTriggerTests {
         context.getLogger().info("Java Event Hub Output function processed a message: " + message);
         output.setValue(message);
     }
+
+   
 }

--- a/run-tests-local.ps1
+++ b/run-tests-local.ps1
@@ -66,7 +66,8 @@ StopOnFailedExecution
 Pop-Location
 
 Write-Host "Copying EventHubs function.json as temporary workaround...."
-Copy-Item "$PSScriptRoot\endtoendtests\function.json" "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutput"
+Copy-Item "$PSScriptRoot\endtoendtests\functionInputString.json" "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutput\function.json"
+Copy-Item "$PSScriptRoot\endtoendtests\functionInputJson.json" "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutput\function.json"
 
 $proc = start-process -filepath func.exe -WorkingDirectory "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests" -ArgumentList "host start" -PassThru
 # wait for host to start

--- a/run-tests-local.ps1
+++ b/run-tests-local.ps1
@@ -66,8 +66,8 @@ StopOnFailedExecution
 Pop-Location
 
 Write-Host "Copying EventHubs function.json as temporary workaround...."
-Copy-Item "$PSScriptRoot\endtoendtests\functionInputString.json" "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputJSON"
-Copy-Item "$PSScriptRoot\endtoendtests\functionInputJson.json" "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputString"
+Copy-Item "$PSScriptRoot\endtoendtests\functionInputString.json" "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputJSON\function.json"
+Copy-Item "$PSScriptRoot\endtoendtests\functionInputJson.json" "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputString\function.json"
 
 $proc = start-process -filepath func.exe -WorkingDirectory "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests" -ArgumentList "host start" -PassThru
 # wait for host to start

--- a/run-tests-local.ps1
+++ b/run-tests-local.ps1
@@ -66,8 +66,8 @@ StopOnFailedExecution
 Pop-Location
 
 Write-Host "Copying EventHubs function.json as temporary workaround...."
-Copy-Item "$PSScriptRoot\endtoendtests\functionInputString.json" "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutput\function.json"
-Copy-Item "$PSScriptRoot\endtoendtests\functionInputJson.json" "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutput\function.json"
+Copy-Item "$PSScriptRoot\endtoendtests\functionInputString.json" "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputJSON"
+Copy-Item "$PSScriptRoot\endtoendtests\functionInputJson.json" "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputString"
 
 $proc = start-process -filepath func.exe -WorkingDirectory "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests" -ArgumentList "host start" -PassThru
 # wait for host to start

--- a/run-tests-local.ps1
+++ b/run-tests-local.ps1
@@ -66,8 +66,8 @@ StopOnFailedExecution
 Pop-Location
 
 Write-Host "Copying EventHubs function.json as temporary workaround...."
-Copy-Item "$PSScriptRoot\endtoendtests\functionInputString.json" "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputJSON\function.json"
-Copy-Item "$PSScriptRoot\endtoendtests\functionInputJson.json" "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputString\function.json"
+Copy-Item "$PSScriptRoot\endtoendtests\functionInputJson.json" "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputJSON\function.json"
+Copy-Item "$PSScriptRoot\endtoendtests\functionInputString.json" "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests\EventHubTriggerAndOutputString\function.json"
 
 $proc = start-process -filepath func.exe -WorkingDirectory "$PSScriptRoot\endtoendtests\target\azure-functions\azure-functions-java-endtoendtests" -ArgumentList "host start" -PassThru
 # wait for host to start

--- a/src/main/java/com/microsoft/azure/functions/worker/binding/RpcComplexDataSources.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/binding/RpcComplexDataSources.java
@@ -9,6 +9,8 @@ import java.util.stream.*;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.*;
+
 import org.apache.commons.lang3.reflect.*;
 
 import com.microsoft.azure.functions.*;
@@ -75,6 +77,7 @@ final class RpcJsonDataSource extends DataSource<String> {
         RELAXED_JSON_MAPPER.enable(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES);
 
         JSON_DATA_OPERATIONS.addOperation(TYPE_STRICT_CONVERSION, String.class, s -> s);
+        JSON_DATA_OPERATIONS.addOperation(TYPE_STRICT_CONVERSION, String[].class, s -> RELAXED_JSON_MAPPER.readValue(s, String[].class));
         JSON_DATA_OPERATIONS.addGuardOperation(TYPE_RELAXED_CONVERSION, (s, t) -> RELAXED_JSON_MAPPER.readValue(s, TypeUtils.getRawType(t, null)));
     }
 }


### PR DESCRIPTION
Fixes #203 

Adds support to bind string array. Example Json string
```
String inStringArray = "[\"test1\", \"test2\"]";
```
binds to String[]

If input is a JSON string of POJOs, it can either bind to List<String> or POJO[]