### PR TITLE
name from custom annotation overrides

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/worker/broker/CoreTypeResolver.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/CoreTypeResolver.java
@@ -7,87 +7,92 @@ import com.microsoft.azure.functions.*;
 import com.microsoft.azure.functions.annotation.*;
 
 public class CoreTypeResolver {
-  private static boolean isOutputParameter(Type target) {
-    if (target instanceof ParameterizedType) {
-      target = ((ParameterizedType) target).getRawType();
-    }
-    return (target instanceof Class<?>)
-        && (OutputBinding.class.isAssignableFrom((Class<?>) target));
-  }
+	private static boolean isOutputParameter(Type target) {
+		if (target instanceof ParameterizedType) {
+			target = ((ParameterizedType) target).getRawType();
+		}
+		return (target instanceof Class<?>) && (OutputBinding.class.isAssignableFrom((Class<?>) target));
+	}
 
-  public static Type getParameterizedActualTypeArgumentsType(Type paramType) {
-    if (paramType instanceof ParameterizedType) {
-      ParameterizedType generics = (ParameterizedType) paramType;
-      Type[] arguments = generics.getActualTypeArguments();
-      if (arguments.length > 0) {
-        return arguments[0];
-      }
-    }
-    return Object.class;
-  }
+	public static Type getParameterizedActualTypeArgumentsType(Type paramType) {
+		if (paramType instanceof ParameterizedType) {
+			ParameterizedType generics = (ParameterizedType) paramType;
+			Type[] arguments = generics.getActualTypeArguments();
+			if (arguments.length > 0) {
+				return arguments[0];
+			}
+		}
+		return Object.class;
+	}
 
-  public static boolean isValidOutputType(Type target) {
-    if (!isOutputParameter(target)) {
-      return false;
-    }
-    target = getParameterizedActualTypeArgumentsType(target);
-    return !isOutputParameter(target);
-  }
+	public static boolean isValidOutputType(Type target) {
+		if (!isOutputParameter(target)) {
+			return false;
+		}
+		target = getParameterizedActualTypeArgumentsType(target);
+		return !isOutputParameter(target);
+	}
 
-  public static boolean isHttpResponse(Type target) {
-    return HttpResponseMessage.class.isAssignableFrom(getRuntimeClass(target));
-  }
+	public static boolean isHttpResponse(Type target) {
+		return HttpResponseMessage.class.isAssignableFrom(getRuntimeClass(target));
+	}
 
-  public static Class<?> getRuntimeClass(Type type) {
-    if (type instanceof ParameterizedType) {
-      type = ((ParameterizedType) type).getRawType();
-    }
-    return (Class<?>) type;
-  }
+	public static Class<?> getRuntimeClass(Type type) {
+		if (type instanceof ParameterizedType) {
+			type = ((ParameterizedType) type).getRawType();
+		}
+		return (Class<?>) type;
+	}
 
-  public static String getAnnotationName(Parameter parameter) {
-    Annotation[] annotations = parameter.getAnnotations();
-    for (Annotation annotation : annotations) {
-      CustomBinding customBindingAnnotation = annotation.annotationType()
-          .getAnnotation(CustomBinding.class);
-      if (customBindingAnnotation != null) {
-        return getBindingNameFromCustomBindingAnnotation(customBindingAnnotation);
-      } else if (annotation.toString().contains("com.microsoft.azure.functions.annotation")) {
-        return getBindingNameFromAnnotation(annotation);
-      }
-    }
-    return null;
-  }
+	public static String getAnnotationName(Parameter parameter) {
+		Annotation[] annotations = parameter.getAnnotations();
+		String annotationName = null;
 
-  private static String getBindingNameFromAnnotation(Annotation annotation) {
-    for (Method annotationMethod : annotation.getClass().getMethods()) {
-      if (annotationMethod.getName().equals("name")) {
-        try {
-          return (String) annotationMethod.invoke(annotation);
-        } catch (Exception ex) {
-          // Ignore
-          return null;
-        }
-      }
-    }
-    return null;
-  }
+		for (Annotation annotation : annotations) {
+			if (annotation.toString().contains("com.microsoft.azure.functions.annotation")) {
+				annotationName = getBindingNameFromAnnotation(annotation);
+			}
+			if (annotationName == null) {
+				CustomBinding customBindingAnnotation = annotation.annotationType().getAnnotation(CustomBinding.class);
+				if (customBindingAnnotation != null) {
+					annotationName = getBindingNameFromAnnotation(annotation);
+					if (annotationName == null) {
+						annotationName = getBindingNameFromCustomBindingAnnotation(customBindingAnnotation);
+					}
+				}
+			}
+		}
+		return annotationName;
+	}
 
-  private static String getBindingNameFromCustomBindingAnnotation(
-      CustomBinding customBindingAnnotation) {
-    try {
-      return customBindingAnnotation.name();
-    } catch (Exception ex) {
-      // Ignore
-      return null;
-    }
-  }
+	private static String getBindingNameFromAnnotation(Annotation annotation) {
+		for (Method annotationMethod : annotation.getClass().getMethods()) {
+			if (annotationMethod.getName().equals("name")) {
+				try {
+					return (String) annotationMethod.invoke(annotation);
+				} catch (Exception ex) {
+					// Ignore
+					return null;
+				}
+			}
+		}
+		return null;
+	}
 
-  static String getBindingNameAnnotation(Parameter param) {
-    BindingName paramAnnotation = param.getDeclaredAnnotation(BindingName.class);
-    if (paramAnnotation != null) {
-      return paramAnnotation.value();
-    }
-    return new String("");
-  }
+	private static String getBindingNameFromCustomBindingAnnotation(CustomBinding customBindingAnnotation) {
+		try {
+			return customBindingAnnotation.name();
+		} catch (Exception ex) {
+			// Ignore
+			return null;
+		}
+	}
+
+	static String getBindingNameAnnotation(Parameter param) {
+		BindingName paramAnnotation = param.getDeclaredAnnotation(BindingName.class);
+		if (paramAnnotation != null) {
+			return paramAnnotation.value();
+		}
+		return new String("");
+	}
 }

--- a/src/test/java/com/microsoft/azure/functions/worker/broker/tests/CoreTypeResolverTests.java
+++ b/src/test/java/com/microsoft/azure/functions/worker/broker/tests/CoreTypeResolverTests.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.functions.annotation.*;
 import com.microsoft.azure.functions.worker.binding.tests.RpcHttpRequestDataSourceTests;
 import com.microsoft.azure.functions.worker.broker.CoreTypeResolver;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.*;
 
 import static com.microsoft.azure.functions.worker.broker.CoreTypeResolver.getRuntimeClass;
@@ -17,134 +18,151 @@ import static org.junit.Assert.*;
 
 public class CoreTypeResolverTests {
 
-  public void CustomBinding_Valid(@HttpTrigger(name = "req", methods = { HttpMethod.GET,
-      HttpMethod.POST }, authLevel = AuthorizationLevel.FUNCTION) HttpRequestMessage<String> request,
-      @TestCustomBinding(index = "testIndex", path = "testPath") String customInput) {
-  }
+	public void CustomBinding_Valid(
+			@HttpTrigger(name = "req", methods = { HttpMethod.GET,
+					HttpMethod.POST }, authLevel = AuthorizationLevel.FUNCTION) HttpRequestMessage<String> request,
+			@TestCustomBindingNoName(index = "testIndex", path = "testPath") String customInput) {
+	}
 
-  public void CustomBinding_Invalid(
-      @InvalidCustomBinding(index = "testIndex", path = "testPath") String customInput) {
-  }
+	public void TestCustomBindingName_OverridesCustomBindingName(
+			@HttpTrigger(name = "req", methods = { HttpMethod.GET,
+					HttpMethod.POST }, authLevel = AuthorizationLevel.FUNCTION) HttpRequestMessage<String> request,
+			@TestCustomBinding(index = "testIndex", path = "testPath", name = "testMessage") String customInput) {
+	}
 
-  @Test
-  public void testIsValidOutputType() throws Exception {
-    assertFalse(isValidOutputType(Integer.class));
-    assertFalse(isValidOutputType(int.class));
-    assertTrue(isValidOutputType(returnTypeOf("outputInteger")));
-    assertFalse(isValidOutputType(returnTypeOf("outputOutputInteger")));
-    assertTrue(isValidOutputType(ExtendedOutputBinding.class));
-    assertFalse(isValidOutputType(returnTypeOf("listInteger")));
-    assertTrue(isValidOutputType(returnTypeOf("outputListInteger")));
-    assertTrue(isValidOutputType(returnTypeOf("exoutputInteger")));
-    assertTrue(isValidOutputType(returnTypeOf("exoutputListInteger")));
-    assertFalse(isValidOutputType(returnTypeOf("exoutputOutputInteger")));
-    assertFalse(isValidOutputType(returnTypeOf("outputExoutputInteger")));
-  }
+	public void CustomBinding_Invalid(
+			@InvalidCustomBinding(index = "testIndex", path = "testPath") String customInput) {
+	}
 
-  @Test
-  public void testGetRuntimeClass() throws Exception {
-    assertEquals(Integer.class, getRuntimeClass(Integer.class));
-    assertEquals(Integer.TYPE, getRuntimeClass(int.class));
-    assertEquals(OutputBinding.class, getRuntimeClass(returnTypeOf("outputInteger")));
-    assertEquals(OutputBinding.class, getRuntimeClass(returnTypeOf("outputOutputInteger")));
-    assertEquals(List.class, getRuntimeClass(returnTypeOf("listInteger")));
-    assertEquals(OutputBinding.class, getRuntimeClass(returnTypeOf("outputListInteger")));
-    assertEquals(GenericExtendedOutputBinding.class,
-        getRuntimeClass(returnTypeOf("exoutputOutputInteger")));
-    assertEquals(OutputBinding.class, getRuntimeClass(returnTypeOf("outputExoutputInteger")));
-  }
+	@Test
+	public void testIsValidOutputType() throws Exception {
+		assertFalse(isValidOutputType(Integer.class));
+		assertFalse(isValidOutputType(int.class));
+		assertTrue(isValidOutputType(returnTypeOf("outputInteger")));
+		assertFalse(isValidOutputType(returnTypeOf("outputOutputInteger")));
+		assertTrue(isValidOutputType(ExtendedOutputBinding.class));
+		assertFalse(isValidOutputType(returnTypeOf("listInteger")));
+		assertTrue(isValidOutputType(returnTypeOf("outputListInteger")));
+		assertTrue(isValidOutputType(returnTypeOf("exoutputInteger")));
+		assertTrue(isValidOutputType(returnTypeOf("exoutputListInteger")));
+		assertFalse(isValidOutputType(returnTypeOf("exoutputOutputInteger")));
+		assertFalse(isValidOutputType(returnTypeOf("outputExoutputInteger")));
+	}
 
-  @Test
-  public void getNameFromCustomBinding() {
-    Method customBindingValid = getFunctionMethod("CustomBinding_Valid");
-    Parameter[] parameters = customBindingValid.getParameters();
-    for (Parameter parameter : parameters) {
-      String annotationName = CoreTypeResolver.getAnnotationName(parameter);
-      assertNotNull(annotationName);
-    }
-  }
+	@Test
+	public void testGetRuntimeClass() throws Exception {
+		assertEquals(Integer.class, getRuntimeClass(Integer.class));
+		assertEquals(Integer.TYPE, getRuntimeClass(int.class));
+		assertEquals(OutputBinding.class, getRuntimeClass(returnTypeOf("outputInteger")));
+		assertEquals(OutputBinding.class, getRuntimeClass(returnTypeOf("outputOutputInteger")));
+		assertEquals(List.class, getRuntimeClass(returnTypeOf("listInteger")));
+		assertEquals(OutputBinding.class, getRuntimeClass(returnTypeOf("outputListInteger")));
+		assertEquals(GenericExtendedOutputBinding.class, getRuntimeClass(returnTypeOf("exoutputOutputInteger")));
+		assertEquals(OutputBinding.class, getRuntimeClass(returnTypeOf("outputExoutputInteger")));
+	}
 
-  @Test
-  public void getNameFromCustomBinding_ReturnsNull() {
-    Method customBindingInvalid = getFunctionMethod("CustomBinding_Invalid");
-    Parameter[] parameters = customBindingInvalid.getParameters();
-    for (Parameter parameter : parameters) {
-      String annotationName = CoreTypeResolver.getAnnotationName(parameter);
-      assertNull(annotationName);
-    }
-  }
+	@Test
+	public void getNameFromCustomBinding() {
+		Method customBindingValid = getFunctionMethod("CustomBinding_Valid");
+		Parameter[] parameters = customBindingValid.getParameters();
+		for (Parameter parameter : parameters) {
+			String annotationName = CoreTypeResolver.getAnnotationName(parameter);
+			assertNotNull(annotationName);
+		}
+	}
 
-  private OutputBinding<Integer> outputInteger() {
-    return null;
-  }
+	@Test
+	public void getNameFromTestCustomBinding() {
+		Method customBindingValid = getFunctionMethod("TestCustomBindingName_OverridesCustomBindingName");
+		Parameter[] parameters = customBindingValid.getParameters();
+		for (Parameter parameter : parameters) {
+			String annotationName = CoreTypeResolver.getAnnotationName(parameter);
+			assertNotNull(annotationName);
+			assertTrue(StringUtils.isNotEmpty(annotationName));
+		}
+	}
 
-  private OutputBinding<OutputBinding<Integer>> outputOutputInteger() {
-    return null;
-  }
+	@Test
+	public void getNameFromCustomBinding_ReturnsNull() {
+		Method customBindingInvalid = getFunctionMethod("CustomBinding_Invalid");
+		Parameter[] parameters = customBindingInvalid.getParameters();
+		for (Parameter parameter : parameters) {
+			String annotationName = CoreTypeResolver.getAnnotationName(parameter);
+			assertNull(annotationName);
+		}
+	}
 
-  private List<Integer> listInteger() {
-    return null;
-  }
+	private OutputBinding<Integer> outputInteger() {
+		return null;
+	}
 
-  private OutputBinding<List<Integer>> outputListInteger() {
-    return null;
-  }
+	private OutputBinding<OutputBinding<Integer>> outputOutputInteger() {
+		return null;
+	}
 
-  private GenericExtendedOutputBinding<Integer> exoutputInteger() {
-    return null;
-  }
+	private List<Integer> listInteger() {
+		return null;
+	}
 
-  private GenericExtendedOutputBinding<List<Integer>> exoutputListInteger() {
-    return null;
-  }
+	private OutputBinding<List<Integer>> outputListInteger() {
+		return null;
+	}
 
-  private GenericExtendedOutputBinding<OutputBinding<Integer>> exoutputOutputInteger() {
-    return null;
-  }
+	private GenericExtendedOutputBinding<Integer> exoutputInteger() {
+		return null;
+	}
 
-  private OutputBinding<GenericExtendedOutputBinding<Integer>> outputExoutputInteger() {
-    return null;
-  }
+	private GenericExtendedOutputBinding<List<Integer>> exoutputListInteger() {
+		return null;
+	}
 
-  private Type returnTypeOf(String type) throws NoSuchMethodException {
-    Method m = CoreTypeResolverTests.class.getDeclaredMethod(type);
-    m.setAccessible(true);
-    return m.getGenericReturnType();
-  }
+	private GenericExtendedOutputBinding<OutputBinding<Integer>> exoutputOutputInteger() {
+		return null;
+	}
 
-  private class ExtendedOutputBinding implements OutputBinding<Integer> {
-    @Override
-    public Integer getValue() {
-      return null;
-    }
+	private OutputBinding<GenericExtendedOutputBinding<Integer>> outputExoutputInteger() {
+		return null;
+	}
 
-    @Override
-    public void setValue(Integer value) {
-    }
-  }
+	private Type returnTypeOf(String type) throws NoSuchMethodException {
+		Method m = CoreTypeResolverTests.class.getDeclaredMethod(type);
+		m.setAccessible(true);
+		return m.getGenericReturnType();
+	}
 
-  private class GenericExtendedOutputBinding<T> implements OutputBinding<T> {
-    @Override
-    public T getValue() {
-      return null;
-    }
+	private class ExtendedOutputBinding implements OutputBinding<Integer> {
+		@Override
+		public Integer getValue() {
+			return null;
+		}
 
-    @Override
-    public void setValue(T value) {
-    }
-  }
+		@Override
+		public void setValue(Integer value) {
+		}
+	}
 
-  private Method getFunctionMethod(String methodName) {
-    CoreTypeResolverTests coreTypeResolverTests = new CoreTypeResolverTests();
-    Class<? extends CoreTypeResolverTests> testsClass = coreTypeResolverTests.getClass();
-    Method[] methods = testsClass.getMethods();
-    Method functionMethod = null;
-    for (Method method : methods) {
-      if (method.getName() == methodName) {
-        functionMethod = method;
-        break;
-      }
-    }
-    return functionMethod;
-  }
+	private class GenericExtendedOutputBinding<T> implements OutputBinding<T> {
+		@Override
+		public T getValue() {
+			return null;
+		}
+
+		@Override
+		public void setValue(T value) {
+		}
+	}
+
+	private Method getFunctionMethod(String methodName) {
+		CoreTypeResolverTests coreTypeResolverTests = new CoreTypeResolverTests();
+		Class<? extends CoreTypeResolverTests> testsClass = coreTypeResolverTests.getClass();
+		Method[] methods = testsClass.getMethods();
+		Method functionMethod = null;
+		for (Method method : methods) {
+			if (method.getName() == methodName) {
+				functionMethod = method;
+				break;
+			}
+		}
+		return functionMethod;
+	}
 }

--- a/src/test/java/com/microsoft/azure/functions/worker/broker/tests/TestCustomBindingNoName.java
+++ b/src/test/java/com/microsoft/azure/functions/worker/broker/tests/TestCustomBindingNoName.java
@@ -9,9 +9,8 @@ import com.microsoft.azure.functions.annotation.CustomBinding;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-@CustomBinding(direction = "in", name = "", type = "customBinding")
-public @interface TestCustomBinding {
+@CustomBinding(direction = "in", name = "cutomBindingName", type = "customBinding")
+public @interface TestCustomBindingNoName {
    String index();
    String path();
-   String name();
 }


### PR DESCRIPTION
If Custom annotation defined name(), it overrides name defined in `com.microsoft.azure.functions.annotation.CustomBinding`

```java
@Target(ElementType.PARAMETER)
@Retention(RetentionPolicy.RUNTIME)
@CustomBinding(direction = "in", name = "", type = "customBinding")
public @interface TestCustomBinding {
   String index();
   String path();
   String name();
}

```