### PR TITLE
WIP: Hooks for DI frameworks #310

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/worker/broker/AbstractJavaMethodExecutor.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/AbstractJavaMethodExecutor.java
@@ -1,0 +1,117 @@
+package com.microsoft.azure.functions.worker.broker;
+
+import com.microsoft.azure.functions.rpc.messages.BindingInfo;
+import com.microsoft.azure.functions.worker.WorkerLogManager;
+import com.microsoft.azure.functions.worker.binding.BindingDefinition;
+import com.microsoft.azure.functions.worker.description.FunctionMethodDescriptor;
+import com.microsoft.azure.functions.worker.reflect.ClassLoaderProvider;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+public abstract class AbstractJavaMethodExecutor implements JavaMethodExecutor {
+
+    public static final String SERVICE_META_INF_PATH = "META-INF/service/com.microsoft.azure.functions.worker.FunctionFactory";
+
+    public AbstractJavaMethodExecutor(FunctionMethodDescriptor descriptor, Map<String, BindingInfo> bindingInfos, ClassLoaderProvider classLoaderProvider)
+            throws MalformedURLException, ClassNotFoundException, NoSuchMethodException {
+        descriptor.validateMethodInfo();
+
+        this.classLoader = classLoaderProvider.createClassLoader();
+        this.containingClass = getContainingClass(descriptor.getFullClassName());
+        this.overloadResolver = new ParameterResolver();
+
+        for (Method method : this.containingClass.getMethods()) {
+            if (method.getDeclaringClass().getName().equals(descriptor.getFullClassName()) && method.getName().equals(descriptor.getMethodName())) {
+                this.overloadResolver.addCandidate(method);
+            }
+        }
+
+        if (!this.overloadResolver.hasCandidates()) {
+            throw new NoSuchMethodException("There are no methods named \"" + descriptor.getName() + "\" in class \"" + descriptor.getFullClassName() + "\"");
+        }
+
+        if (this.overloadResolver.hasMultipleCandidates()) {
+            throw new UnsupportedOperationException("Found more than one function with method name \"" + descriptor.getName() + "\" in class \"" + descriptor.getFullClassName() + "\"");
+        }
+
+        this.bindingDefinitions = new HashMap<>();
+
+        for (Map.Entry<String, BindingInfo> entry : bindingInfos.entrySet()) {
+            this.bindingDefinitions.put(entry.getKey(), new BindingDefinition(entry.getKey(), entry.getValue()));
+        }
+        resolveFunctionFactory();
+
+    }
+
+
+    @Override
+    public boolean hasFactory() {
+        return functionFactory != null;
+    }
+
+    @Override
+    public Map<String, BindingDefinition> getBindingDefinitions() { return this.bindingDefinitions; }
+
+    @Override
+    public ParameterResolver getOverloadResolver() { return this.overloadResolver; }
+
+    protected Object createFunctionInstance() throws Exception {
+        if (functionFactory == null) {
+            return this.containingClass.newInstance();
+        }
+        return functionFactory.invoke(null, containingClass);
+    }
+
+    protected Logger getLogger() {
+        return WorkerLogManager.getSystemLogger();
+    }
+
+    protected void resolveFunctionFactory() throws ClassNotFoundException, NoSuchMethodException {
+        InputStream is = classLoader.getResourceAsStream(SERVICE_META_INF_PATH);
+        if (is == null) {
+            getLogger().info("resolveFunctionFactory could not find descriptor");
+            return;
+        }
+        BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+        Class factoryClass = null;
+        String factoryName = null;
+        try {
+            factoryName = reader.readLine().trim();
+            factoryClass = classLoader.loadClass(factoryName);
+        } catch (ClassNotFoundException e) {
+            throw new ClassNotFoundException("Could not resolve function factory class " + factoryName);
+        } catch (IOException io) {
+            throw new ClassNotFoundException("Could not resolve function factory class");
+        }
+        try {
+            functionFactory = factoryClass.getMethod("newInstance", Class.class);
+        } catch (NoSuchMethodException e) {
+            throw new NoSuchMethodException("function factory class must have a static \"newInstance\" method that takes one Class parameter and returns an Object");
+        }
+        try {
+            is.close();
+        } catch (IOException e) {
+            // ignore
+        }
+        getLogger().info("Using " + factoryName + " to instantiate your function class");
+    }
+
+    abstract protected Class<?> getContainingClass(String className) throws ClassNotFoundException;
+
+
+
+
+    protected ClassLoader classLoader;
+    protected Class<?> containingClass;
+    protected Method functionFactory;
+    protected final ParameterResolver overloadResolver;
+    protected final Map<String, BindingDefinition> bindingDefinitions;
+}

--- a/src/main/java/com/microsoft/azure/functions/worker/broker/EnhancedJavaMethodExecutorImpl.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/EnhancedJavaMethodExecutorImpl.java
@@ -1,6 +1,7 @@
 package com.microsoft.azure.functions.worker.broker;
 
 import java.lang.reflect.*;
+import java.net.MalformedURLException;
 import java.util.*;
 
 import com.microsoft.azure.functions.worker.binding.*;
@@ -12,59 +13,28 @@ import com.microsoft.azure.functions.rpc.messages.*;
  * Used to executor of arbitrary Java method in any JAR using reflection.
  * Thread-Safety: Multiple thread.
  */
-public class EnhancedJavaMethodExecutorImpl implements JavaMethodExecutor {
+public class EnhancedJavaMethodExecutorImpl extends AbstractJavaMethodExecutor {
     public EnhancedJavaMethodExecutorImpl(FunctionMethodDescriptor descriptor, Map<String, BindingInfo> bindingInfos, ClassLoaderProvider classLoaderProvider)
-            throws ClassNotFoundException, NoSuchMethodException
+            throws MalformedURLException, ClassNotFoundException, NoSuchMethodException
     {
-        descriptor.validateMethodInfo();
-
-        this.classLoader = classLoaderProvider.createClassLoader();
-        this.containingClass = getContainingClass(descriptor.getFullClassName());
-        this.overloadResolver = new ParameterResolver();
-
-        for (Method method : this.containingClass.getMethods()) {
-            if (method.getDeclaringClass().getName().equals(descriptor.getFullClassName()) && method.getName().equals(descriptor.getMethodName())) {
-                this.overloadResolver.addCandidate(method);
-            }
-        }
-
-        if (!this.overloadResolver.hasCandidates()) {
-            throw new NoSuchMethodException("There are no methods named \"" + descriptor.getName() + "\" in class \"" + descriptor.getFullClassName() + "\"");
-        }
-
-        if (this.overloadResolver.hasMultipleCandidates()) {
-            throw new UnsupportedOperationException("Found more than one function with method name \"" + descriptor.getName() + "\" in class \"" + descriptor.getFullClassName() + "\"");
-        }
-
-        this.bindingDefinitions = new HashMap<>();
-
-        for (Map.Entry<String, BindingInfo> entry : bindingInfos.entrySet()) {
-            this.bindingDefinitions.put(entry.getKey(), new BindingDefinition(entry.getKey(), entry.getValue()));
-        }
+        super(descriptor, bindingInfos, classLoaderProvider);
     }
-
-    public Map<String, BindingDefinition> getBindingDefinitions() { return this.bindingDefinitions; }
-
-    public ParameterResolver getOverloadResolver() { return this.overloadResolver; }
 
     public void execute(BindingDataStore dataStore) throws Exception {
         try {
             Thread.currentThread().setContextClassLoader(this.classLoader);
             Object retValue = this.overloadResolver.resolve(dataStore)
                     .orElseThrow(() -> new NoSuchMethodException("Cannot locate the method signature with the given input"))
-                    .invoke(() -> this.containingClass.newInstance());
+                    .invoke(() -> createFunctionInstance());
             dataStore.setDataTargetValue(BindingDataStore.RETURN_NAME, retValue);
         } finally {
             Thread.currentThread().setContextClassLoader(ClassLoader.getSystemClassLoader());
         }
     }
 
-    private Class<?> getContainingClass(String className) throws ClassNotFoundException {
+    @Override
+    protected Class<?> getContainingClass(String className) throws ClassNotFoundException {
         return Class.forName(className, false, this.classLoader);
     }
 
-    private final Class<?> containingClass;
-    private final ClassLoader classLoader;
-    private final ParameterResolver overloadResolver;
-    private final Map<String, BindingDefinition> bindingDefinitions;
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodExecutor.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodExecutor.java
@@ -14,5 +14,7 @@ public interface JavaMethodExecutor {
 
     ParameterResolver getOverloadResolver();
 
+    boolean hasFactory();
+
     void execute(BindingDataStore dataStore) throws Exception;
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodExecutorImpl.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodExecutorImpl.java
@@ -1,9 +1,15 @@
 package com.microsoft.azure.functions.worker.broker;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.reflect.*;
 import java.net.*;
 import java.util.*;
+import java.util.logging.Logger;
 
+import com.microsoft.azure.functions.worker.WorkerLogManager;
 import com.microsoft.azure.functions.worker.binding.*;
 import com.microsoft.azure.functions.worker.description.*;
 import com.microsoft.azure.functions.worker.reflect.*;
@@ -13,53 +19,24 @@ import com.microsoft.azure.functions.rpc.messages.*;
  * Used to executor of arbitrary Java method in any JAR using reflection.
  * Thread-Safety: Multiple thread.
  */
-public class JavaMethodExecutorImpl implements JavaMethodExecutor {
+public class JavaMethodExecutorImpl extends AbstractJavaMethodExecutor {
     public JavaMethodExecutorImpl(FunctionMethodDescriptor descriptor, Map<String, BindingInfo> bindingInfos, ClassLoaderProvider classLoaderProvider)
             throws MalformedURLException, ClassNotFoundException, NoSuchMethodException
     {
-        descriptor.validateMethodInfo();
-
-        this.containingClass = getContainingClass(descriptor.getFullClassName(), classLoaderProvider);
-        this.overloadResolver = new ParameterResolver();
-
-        for (Method method : this.containingClass.getMethods()) {
-            if (method.getDeclaringClass().getName().equals(descriptor.getFullClassName()) && method.getName().equals(descriptor.getMethodName())) {
-                this.overloadResolver.addCandidate(method);
-            }
-        }
-
-        if (!this.overloadResolver.hasCandidates()) {
-            throw new NoSuchMethodException("There are no methods named \"" + descriptor.getName() + "\" in class \"" + descriptor.getFullClassName() + "\"");
-        }
-
-        if (this.overloadResolver.hasMultipleCandidates()) {
-            throw new UnsupportedOperationException("Found more than one function with method name \"" + descriptor.getName() + "\" in class \"" + descriptor.getFullClassName() + "\"");
-        }
-
-        this.bindingDefinitions = new HashMap<>();
-
-        for (Map.Entry<String, BindingInfo> entry : bindingInfos.entrySet()) {
-            this.bindingDefinitions.put(entry.getKey(), new BindingDefinition(entry.getKey(), entry.getValue()));
-        }
+        super(descriptor, bindingInfos, classLoaderProvider);
     }
-
-    public Map<String, BindingDefinition> getBindingDefinitions() { return this.bindingDefinitions; }
-
-    public ParameterResolver getOverloadResolver() { return this.overloadResolver; }
 
     public void execute(BindingDataStore dataStore) throws Exception {
         Object retValue = this.overloadResolver.resolve(dataStore)
                 .orElseThrow(() -> new NoSuchMethodException("Cannot locate the method signature with the given input"))
-                .invoke(() -> this.containingClass.newInstance());
+                .invoke(() -> createFunctionInstance());
         dataStore.setDataTargetValue(BindingDataStore.RETURN_NAME, retValue);
     }
 
-    private Class<?> getContainingClass(String className, ClassLoaderProvider classLoaderProvider) throws ClassNotFoundException {
-        ClassLoader classLoader = classLoaderProvider.createClassLoader();
+    @Override
+    protected Class<?> getContainingClass(String className) throws ClassNotFoundException {
         return Class.forName(className, true, classLoader);
     }
 
-    private Class<?> containingClass;
-    private final ParameterResolver overloadResolver;
-    private final Map<String, BindingDefinition> bindingDefinitions;
+
 }

--- a/src/test/java/com/microsoft/azure/functions/worker/broker/tests/BadMethodFunctionFactory.java
+++ b/src/test/java/com/microsoft/azure/functions/worker/broker/tests/BadMethodFunctionFactory.java
@@ -1,0 +1,11 @@
+package com.microsoft.azure.functions.worker.broker.tests;
+
+public class BadMethodFunctionFactory {
+    public Object create(Class clz) {
+        try {
+            return clz.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/microsoft/azure/functions/worker/broker/tests/CustomFunctionFactory.java
+++ b/src/test/java/com/microsoft/azure/functions/worker/broker/tests/CustomFunctionFactory.java
@@ -1,0 +1,11 @@
+package com.microsoft.azure.functions.worker.broker.tests;
+
+public class CustomFunctionFactory {
+    public Object newInstance(Class clz) {
+        try {
+            return clz.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/microsoft/azure/functions/worker/broker/tests/JavaMethodExecutorTests.java
+++ b/src/test/java/com/microsoft/azure/functions/worker/broker/tests/JavaMethodExecutorTests.java
@@ -3,6 +3,11 @@ package com.microsoft.azure.functions.worker.broker.tests;
 import org.junit.*;
 
 import static junit.framework.TestCase.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.*;
 
 
@@ -12,12 +17,12 @@ import com.microsoft.azure.functions.worker.description.*;
 import com.microsoft.azure.functions.worker.reflect.*;
 
 public class JavaMethodExecutorTests {
-	
-	@Test    
+	@Test
     public void functionMethodLoadSucceeds_8() throws Exception {
 		FunctionMethodDescriptor descriptor = new FunctionMethodDescriptor("testid", "TestHttpTrigger","com.microsoft.azure.functions.worker.broker.tests.TestFunctionsClass.TestHttpTrigger","TestFunctionsClass.jar");
 		Map<String, BindingInfo> bindings = new HashMap<>();
 		bindings.put("$return", BindingInfo.newBuilder().setDirection(BindingInfo.Direction.out).build());
+		System.setProperty("java.specification.version", "1.8");
 		JavaMethodExecutor executor = new FactoryJavaMethodExecutor().getJavaMethodExecutor(descriptor, bindings, new FactoryClassLoader().createClassLoaderProvider());
 		assertTrue(executor.getOverloadResolver().hasCandidates());
 		assertFalse(executor.getOverloadResolver().hasMultipleCandidates());
@@ -68,5 +73,87 @@ public class JavaMethodExecutorTests {
 		Map<String, BindingInfo> bindings = new HashMap<>();
 		bindings.put("$return", BindingInfo.newBuilder().setDirection(BindingInfo.Direction.out).build());
 		JavaMethodExecutor executor = new FactoryJavaMethodExecutor().getJavaMethodExecutor(descriptor, bindings, new FactoryClassLoader().createClassLoaderProvider());
+	}
+
+	// used to override function factory path
+	static class FunctionFactoryClassLoader extends ClassLoader {
+		private final String metaInfLocation;
+
+		public FunctionFactoryClassLoader(ClassLoader parent, String location) {
+			super(parent);
+			this.metaInfLocation = location;
+		}
+
+		@Override
+		public InputStream getResourceAsStream(String name) {
+			if (AbstractJavaMethodExecutor.SERVICE_META_INF_PATH.equals(name)) name = metaInfLocation;
+			return super.getResourceAsStream(name);
+		}
+	}
+	@Test
+	public void functionFunctionFactorySucceeds_8() throws Exception {
+		System.setProperty("java.specification.version", "1.8");
+		FunctionFactoryClassLoader cl = new FunctionFactoryClassLoader(JavaMethodExecutorTests.class.getClassLoader(), "functionFactory.txt");
+		testFunctionFactory(cl);
+	}
+
+	@Test(expected = NoSuchMethodException.class)
+	public void functionFunctionFactoryBadMethod_8() throws Exception {
+		System.setProperty("java.specification.version", "1.8");
+		FunctionFactoryClassLoader cl = new FunctionFactoryClassLoader(JavaMethodExecutorTests.class.getClassLoader(), "badMethodFunctionFactory.txt");
+		testFunctionFactory(cl);
+	}
+
+	@Test(expected = ClassNotFoundException.class)
+	public void functionFunctionFactoryNotFound_8() throws Exception {
+		System.setProperty("java.specification.version", "1.8");
+		FunctionFactoryClassLoader cl = new FunctionFactoryClassLoader(JavaMethodExecutorTests.class.getClassLoader(), "notFoundFunctionFactory.txt");
+		testFunctionFactory(cl);
+	}
+
+	@Test
+	public void functionFunctionFactorySucceeds_11() throws Exception {
+		System.setProperty("java.specification.version", "11");
+		FunctionFactoryClassLoader cl = new FunctionFactoryClassLoader(JavaMethodExecutorTests.class.getClassLoader(), "functionFactory.txt");
+		testFunctionFactory(cl);
+	}
+
+	@Test(expected = NoSuchMethodException.class)
+	public void functionFunctionFactoryBadMethod_11() throws Exception {
+		System.setProperty("java.specification.version", "11");
+		FunctionFactoryClassLoader cl = new FunctionFactoryClassLoader(JavaMethodExecutorTests.class.getClassLoader(), "badMethodFunctionFactory.txt");
+		testFunctionFactory(cl);
+	}
+
+	@Test(expected = ClassNotFoundException.class)
+	public void functionFunctionFactoryNotFound_11() throws Exception {
+		System.setProperty("java.specification.version", "11");
+		FunctionFactoryClassLoader cl = new FunctionFactoryClassLoader(JavaMethodExecutorTests.class.getClassLoader(), "notFoundFunctionFactory.txt");
+		testFunctionFactory(cl);
+	}
+
+	private void testFunctionFactory(FunctionFactoryClassLoader cl) throws MalformedURLException, ClassNotFoundException, NoSuchMethodException {
+		FunctionMethodDescriptor descriptor = new FunctionMethodDescriptor("testid", "TestHttpTrigger","com.microsoft.azure.functions.worker.broker.tests.TestFunctionsClass.TestHttpTrigger","TestFunctionsClass.jar");
+		Map<String, BindingInfo> bindings = new HashMap<>();
+		bindings.put("$return", BindingInfo.newBuilder().setDirection(BindingInfo.Direction.out).build());
+		JavaMethodExecutor executor = new FactoryJavaMethodExecutor().getJavaMethodExecutor(descriptor, bindings, new ClassLoaderProvider() {
+			@Override
+			public void addCustomerUrl(URL url) throws IOException {
+
+			}
+
+			@Override
+			public void addWorkerUrl(URL url) throws IOException {
+
+			}
+
+			@Override
+			public ClassLoader createClassLoader() {
+				return cl;
+			}
+		});
+		assertTrue(executor.hasFactory());
+		assertTrue(executor.getOverloadResolver().hasCandidates());
+		assertFalse(executor.getOverloadResolver().hasMultipleCandidates());
 	}
 }

--- a/src/test/resources/badMethodFunctionFactory.txt
+++ b/src/test/resources/badMethodFunctionFactory.txt
@@ -1,0 +1,1 @@
+com.microsoft.azure.functions.worker.broker.tests.BadMethodFunctionFactory

--- a/src/test/resources/functionFactory.txt
+++ b/src/test/resources/functionFactory.txt
@@ -1,0 +1,1 @@
+com.microsoft.azure.functions.worker.broker.tests.CustomFunctionFactory

--- a/src/test/resources/notFoundFunctionFactory.txt
+++ b/src/test/resources/notFoundFunctionFactory.txt
@@ -1,0 +1,1 @@
+com.error.FunctionFactory


### PR DESCRIPTION
This is a work in progress.  Will add tests if there's interest in this.  This simple patch provides a hook so that DI frameworks can instantiate function class instances.  

In my PoC, I was able to hook in Quarkus Arc CDI implementation using this [WIP quarkus azure extension](https://github.com/patriot1burke/quarkus/tree/azure-arc/extensions/azure-functions) so that an [Azure function class could be a CDI bean](https://gist.github.com/patriot1burke/4a1fdaa017ece9cadf18366a3663f3f6#file-function-java-L2-L3).

JavaMethodExecutor looks for a text file META-INF/service/com.microsoft.azure.functions.FunctionFactory in function app.  If exists, reads that file to find a FQN classname.  Does reflection to find a method named "newInstande(Class)".  If this static method exists, it will use that to allocate a function class instance instead of class.newInstance().