### PR TITLE
Add support for java11.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ steps:
    checkLatest: true
 - pwsh: |
      Get-Command mvn
-  displayName: 'Installing Maven'
+  displayName: 'Check Maven is installed'
 - pwsh: |
       $buildNumber = 0      
       if($env:APPVEYOR_REPO_TAG -eq "true") {
@@ -32,10 +32,10 @@ steps:
     CleanTargetFolder: true
   displayName: 'Copying files for artifacts'
 - pwsh: |
-      .\setup-tests.ps1
+      .\setup-tests-pipeline.ps1
   displayName: 'Setting tests'
 - pwsh: |
-      .\run-tests.ps1
+      .\build-run-tests-pipeline.ps1
   env:
     AzureWebJobsStorage: $(AzureWebJobsStorage)
     AzureWebJobsCosmosDBConnectionString: $(AzureWebJobsCosmosDBConnectionString)
@@ -47,8 +47,25 @@ steps:
     SBTopicSubName: $(SBTopicSubName)
     CosmosDBDatabaseName: $(CosmosDBDatabaseName)
     SBQueueName: $(SBQueueName)
-  displayName: 'running tests'
-  continueOnError: true
+  displayName: 'Build & Run tests for java 8'
+  continueOnError: false
+- pwsh: |
+    .\build-run-tests-pipeline.ps1
+  env:
+    JAVA_HOME: 'C:\Program Files\Java\zulu-11-azure-jdk_11.33.15-11.0.4-win_x64'
+    AzureWebJobsStorage: $(AzureWebJobsStorage)
+    AzureWebJobsCosmosDBConnectionString: $(AzureWebJobsCosmosDBConnectionString)
+    AzureWebJobsServiceBus: $(AzureWebJobsServiceBus)
+    AzureWebJobsEventHubSender_2: $(AzureWebJobsEventHubSender_2)
+    AzureWebJobsEventHubReceiver: $(AzureWebJobsEventHubReceiver)
+    AzureWebJobsEventHubSender: $(AzureWebJobsEventHubSender)
+    AzureWebJobsEventHubPath: $(AzureWebJobsEventHubPath)
+    SBTopicName: $(SBTopicName)
+    SBTopicSubName: $(SBTopicSubName)
+    CosmosDBDatabaseName: $(CosmosDBDatabaseName)
+    SBQueueName: $(SBQueueName)
+  displayName: 'Build & Run tests for java 11'
+  continueOnError: false
 - task: CopyFiles@2
   inputs:
     SourceFolder: '$(System.DefaultWorkingDirectory)/testResults'

--- a/build-run-tests-pipeline.ps1
+++ b/build-run-tests-pipeline.ps1
@@ -1,0 +1,53 @@
+# A function that checks exit codes and fails script if an error is found
+function StopOnFailedExecution {
+    if ($LastExitCode)
+    {
+        exit $LastExitCode
+    }
+}
+
+function RunTest([string] $project, [string] $description,[bool] $skipBuild = $false, $filter = $null) {
+    Write-Host "Running test: $description" -ForegroundColor DarkCyan
+    Write-Host "-----------------------------------------------------------------------------" -ForegroundColor DarkCyan
+    Write-Host
+
+    $cmdargs = "test", "$project", "-v", "q", "-l", "trx", "-r",".\testResults"
+    
+    if ($filter) {
+       $cmdargs += "--filter", "$filter"
+    }
+
+    & dotnet $cmdargs | Out-Host
+    $r = $?
+    
+    Write-Host
+    Write-Host "-----------------------------------------------------------------------------" -ForegroundColor DarkCyan
+    Write-Host
+
+    return $r
+}
+
+$currDir =  Get-Location
+
+Write-Host "Building endtoendtests...."
+$Env:Path = $Env:Path+";$currDir\Azure.Functions.Cli"
+Push-Location -Path "./endtoendtests" -StackName javaWorkerDir
+Write-Host "Building azure-functions-maven-com.microsoft.azure.functions.endtoendtests"
+cmd.exe /c '.\..\mvnBuildSkipTests.bat'
+StopOnFailedExecution
+Pop-Location -StackName "javaWorkerDir"
+
+$tests = @(
+  @{project ="endtoendtests\Azure.Functions.Java.Tests.E2E\Azure.Functions.Java.Tests.E2E\Azure.Functions.Java.Tests.E2E.csproj"; description="E2E integration tests"}
+)
+
+$success = $true
+$testRunSucceeded = $true
+
+foreach ($test in $tests){
+    $testRunSucceeded = RunTest $test.project $test.description $testRunSucceeded $test.filter
+    $success = $testRunSucceeded -and $success
+}
+
+if (-not $success) { exit 1 }
+

--- a/endtoendtests/pom.xml
+++ b/endtoendtests/pom.xml
@@ -67,6 +67,34 @@
 			<groupId>com.microsoft.azure.functions</groupId>
 			<artifactId>azure-functions-java-library</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.9</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>28.1-jre</version>
+		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<version>1.4.199</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.8.6</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.10</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<azure.functions.java.library.version>1.3.1-SNAPSHOT</azure.functions.java.library.version>
+		<azure.functions.java.library.version>1.3.1</azure.functions.java.library.version>
 	</properties>
 
 	<licenses>

--- a/setup-tests-pipeline.ps1
+++ b/setup-tests-pipeline.ps1
@@ -1,11 +1,3 @@
-
-# A function that checks exit codes and fails script if an error is found 
-function StopOnFailedExecution {
-  if ($LastExitCode)
-  {
-    exit $LastExitCode
-  }
-}
 Write-Host "$args[0]"
 Write-Host $args[0]
 
@@ -45,10 +37,3 @@ Write-Host "Copying azure-functions-java-worker to  Functions Host workers direc
 Get-ChildItem -Path .\target\* -Include 'azure*' -Exclude '*shaded.jar','*tests.jar' | %{ Copy-Item $_.FullName ".\Azure.Functions.Cli\workers\java\azure-functions-java-worker.jar" }
 Copy-Item ".\worker.config.json" ".\Azure.Functions.Cli\workers\java"
 
-Write-Host "Building endtoendtests...."
-$Env:Path = $Env:Path+";$currDir\Azure.Functions.Cli"
-Push-Location -Path "./endtoendtests" -StackName javaWorkerDir
-Write-Host "Building azure-functions-maven-com.microsoft.azure.functions.endtoendtests"
-cmd.exe /c '.\..\mvnBuildSkipTests.bat'
-StopOnFailedExecution
-Pop-Location -StackName "javaWorkerDir"

--- a/src/main/java/com/microsoft/azure/functions/worker/JavaWorkerClient.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/JavaWorkerClient.java
@@ -28,7 +28,7 @@ public class JavaWorkerClient implements AutoCloseable {
         this.channel = chanBuilder.build();
         this.peer = new AtomicReference<>(null);
         this.handlerSuppliers = new HashMap<>();
-        this.classPathProvider = new DefaultClassLoaderProvider();
+        this.classPathProvider = new FactoryClassLoader().createClassLoaderProvider();
         
         this.addHandlers();
     }
@@ -116,5 +116,5 @@ public class JavaWorkerClient implements AutoCloseable {
     private final ManagedChannel channel;
     private final AtomicReference<StreamingMessagePeer> peer;
     private final Map<StreamingMessage.ContentCase, Supplier<MessageHandler<?, ?>>> handlerSuppliers;
-    private final DefaultClassLoaderProvider classPathProvider;
+    private final ClassLoaderProvider classPathProvider;
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/broker/EnhancedJavaMethodExecutorImpl.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/EnhancedJavaMethodExecutorImpl.java
@@ -1,0 +1,70 @@
+package com.microsoft.azure.functions.worker.broker;
+
+import java.lang.reflect.*;
+import java.util.*;
+
+import com.microsoft.azure.functions.worker.binding.*;
+import com.microsoft.azure.functions.worker.description.*;
+import com.microsoft.azure.functions.worker.reflect.*;
+import com.microsoft.azure.functions.rpc.messages.*;
+
+/**
+ * Used to executor of arbitrary Java method in any JAR using reflection.
+ * Thread-Safety: Multiple thread.
+ */
+public class EnhancedJavaMethodExecutorImpl implements JavaMethodExecutor {
+    public EnhancedJavaMethodExecutorImpl(FunctionMethodDescriptor descriptor, Map<String, BindingInfo> bindingInfos, ClassLoaderProvider classLoaderProvider)
+            throws ClassNotFoundException, NoSuchMethodException
+    {
+        descriptor.validateMethodInfo();
+
+        this.classLoader = classLoaderProvider.createClassLoader();
+        this.containingClass = getContainingClass(descriptor.getFullClassName());
+        this.overloadResolver = new ParameterResolver();
+
+        for (Method method : this.containingClass.getMethods()) {
+            if (method.getName().equals(descriptor.getMethodName())) {
+                this.overloadResolver.addCandidate(method);
+            }
+        }
+
+        if (!this.overloadResolver.hasCandidates()) {
+            throw new NoSuchMethodException("There are no methods named \"" + descriptor.getName() + "\" in class \"" + descriptor.getFullClassName() + "\"");
+        }
+
+        if (this.overloadResolver.hasMultipleCandidates()) {
+            throw new UnsupportedOperationException("Found more than one function with method name \"" + descriptor.getName() + "\" in class \"" + descriptor.getFullClassName() + "\"");
+        }
+
+        this.bindingDefinitions = new HashMap<>();
+
+        for (Map.Entry<String, BindingInfo> entry : bindingInfos.entrySet()) {
+            this.bindingDefinitions.put(entry.getKey(), new BindingDefinition(entry.getKey(), entry.getValue()));
+        }
+    }
+
+    public Map<String, BindingDefinition> getBindingDefinitions() { return this.bindingDefinitions; }
+
+    public ParameterResolver getOverloadResolver() { return this.overloadResolver; }
+
+    public void execute(BindingDataStore dataStore) throws Exception {
+        try {
+            Thread.currentThread().setContextClassLoader(this.classLoader);
+            Object retValue = this.overloadResolver.resolve(dataStore)
+                    .orElseThrow(() -> new NoSuchMethodException("Cannot locate the method signature with the given input"))
+                    .invoke(() -> this.containingClass.newInstance());
+            dataStore.setDataTargetValue(BindingDataStore.RETURN_NAME, retValue);
+        } finally {
+            Thread.currentThread().setContextClassLoader(ClassLoader.getSystemClassLoader());
+        }
+    }
+
+    private Class<?> getContainingClass(String className) throws ClassNotFoundException {
+        return Class.forName(className, true, this.classLoader);
+    }
+
+    private final Class<?> containingClass;
+    private final ClassLoader classLoader;
+    private final ParameterResolver overloadResolver;
+    private final Map<String, BindingDefinition> bindingDefinitions;
+}

--- a/src/main/java/com/microsoft/azure/functions/worker/broker/FactoryJavaMethodExecutor.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/FactoryJavaMethodExecutor.java
@@ -1,0 +1,23 @@
+package com.microsoft.azure.functions.worker.broker;
+
+import com.microsoft.azure.functions.rpc.messages.BindingInfo;
+import com.microsoft.azure.functions.worker.WorkerLogManager;
+import com.microsoft.azure.functions.worker.description.FunctionMethodDescriptor;
+import com.microsoft.azure.functions.worker.reflect.ClassLoaderProvider;
+import org.apache.commons.lang3.SystemUtils;
+
+import java.net.MalformedURLException;
+import java.util.Map;
+
+public class FactoryJavaMethodExecutor {
+    public JavaMethodExecutor getJavaMethodExecutor(FunctionMethodDescriptor descriptor, Map<String, BindingInfo> bindings, ClassLoaderProvider classLoaderProvider)
+            throws MalformedURLException, ClassNotFoundException, NoSuchMethodException {
+        if(SystemUtils.IS_JAVA_1_8) {
+            WorkerLogManager.getSystemLogger().info("Loading JavaMethodExecutorImpl");
+            return new JavaMethodExecutorImpl(descriptor, bindings, classLoaderProvider);
+        } else {
+            WorkerLogManager.getSystemLogger().info("Loading EnhancedJavaMethodExecutorImpl");
+            return new EnhancedJavaMethodExecutorImpl(descriptor, bindings, classLoaderProvider);
+        }
+    }
+}

--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
@@ -31,7 +31,7 @@ public class JavaFunctionBroker {
 		descriptor.validate();
 
 		addSearchPathsToClassLoader(descriptor);
-		JavaMethodExecutor executor = new JavaMethodExecutor(descriptor, bindings, classLoaderProvider);
+		JavaMethodExecutor executor = new FactoryJavaMethodExecutor().getJavaMethodExecutor(descriptor, bindings, classLoaderProvider);
 
 		this.methods.put(descriptor.getId(), new ImmutablePair<>(descriptor.getName(), executor));
 	}

--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodExecutor.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodExecutor.java
@@ -14,53 +14,10 @@ import com.microsoft.azure.functions.rpc.messages.*;
  * Used to executor of arbitrary Java method in any JAR using reflection.
  * Thread-Safety: Multiple thread.
  */
-public class JavaMethodExecutor {
-    public JavaMethodExecutor(FunctionMethodDescriptor descriptor, Map<String, BindingInfo> bindingInfos, ClassLoaderProvider classLoaderProvider)
-            throws MalformedURLException, ClassNotFoundException, NoSuchMethodException
-    {
-        descriptor.validateMethodInfo();
+public interface JavaMethodExecutor {
+    Map<String, BindingDefinition> getBindingDefinitions();
 
-        this.containingClass = getContainingClass(descriptor.getFullClassName(), classLoaderProvider);
-        this.overloadResolver = new ParameterResolver();
+    ParameterResolver getOverloadResolver();
 
-        for (Method method : this.containingClass.getMethods()) {                     
-            if (method.getName().equals(descriptor.getMethodName())) {
-                this.overloadResolver.addCandidate(method);                
-            }
-        }
-
-        if (!this.overloadResolver.hasCandidates()) {
-            throw new NoSuchMethodException("There are no methods named \"" + descriptor.getName() + "\" in class \"" + descriptor.getFullClassName() + "\"");
-        }
-
-        if (this.overloadResolver.hasMultipleCandidates()) {
-            throw new UnsupportedOperationException("Found more than one function with method name \"" + descriptor.getName() + "\" in class \"" + descriptor.getFullClassName() + "\"");
-        }
-
-        this.bindingDefinitions = new HashMap<>();
-        
-        for (Map.Entry<String, BindingInfo> entry : bindingInfos.entrySet()) {
-            this.bindingDefinitions.put(entry.getKey(), new BindingDefinition(entry.getKey(), entry.getValue()));
-        }
-    }
-    
-    Map<String, BindingDefinition> getBindingDefinitions() { return this.bindingDefinitions; }
-    
-    public ParameterResolver getOverloadResolver() { return this.overloadResolver; }
-
-    void execute(BindingDataStore dataStore) throws Exception {
-        Object retValue = this.overloadResolver.resolve(dataStore)
-            .orElseThrow(() -> new NoSuchMethodException("Cannot locate the method signature with the given input"))
-            .invoke(() -> this.containingClass.newInstance());
-        dataStore.setDataTargetValue(BindingDataStore.RETURN_NAME, retValue);
-    }
-    
-    Class<?> getContainingClass(String className, ClassLoaderProvider classLoaderProvider) throws ClassNotFoundException {
-        ClassLoader classLoader = classLoaderProvider.getClassLoader();
-        return Class.forName(className, true, classLoader);
-    }
-
-    private Class<?> containingClass;
-    private final ParameterResolver overloadResolver;
-    private final Map<String, BindingDefinition> bindingDefinitions;
+    void execute(BindingDataStore dataStore) throws Exception;
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodExecutorImpl.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodExecutorImpl.java
@@ -1,0 +1,66 @@
+package com.microsoft.azure.functions.worker.broker;
+
+import java.lang.reflect.*;
+import java.net.*;
+import java.util.*;
+
+import com.microsoft.azure.functions.annotation.*;
+import com.microsoft.azure.functions.worker.binding.*;
+import com.microsoft.azure.functions.worker.description.*;
+import com.microsoft.azure.functions.worker.reflect.*;
+import com.microsoft.azure.functions.rpc.messages.*;
+
+/**
+ * Used to executor of arbitrary Java method in any JAR using reflection.
+ * Thread-Safety: Multiple thread.
+ */
+public class JavaMethodExecutorImpl implements JavaMethodExecutor {
+    public JavaMethodExecutorImpl(FunctionMethodDescriptor descriptor, Map<String, BindingInfo> bindingInfos, ClassLoaderProvider classLoaderProvider)
+            throws MalformedURLException, ClassNotFoundException, NoSuchMethodException
+    {
+        descriptor.validateMethodInfo();
+
+        this.containingClass = getContainingClass(descriptor.getFullClassName(), classLoaderProvider);
+        this.overloadResolver = new ParameterResolver();
+
+        for (Method method : this.containingClass.getMethods()) {
+            if (method.getName().equals(descriptor.getMethodName())) {
+                this.overloadResolver.addCandidate(method);
+            }
+        }
+
+        if (!this.overloadResolver.hasCandidates()) {
+            throw new NoSuchMethodException("There are no methods named \"" + descriptor.getName() + "\" in class \"" + descriptor.getFullClassName() + "\"");
+        }
+
+        if (this.overloadResolver.hasMultipleCandidates()) {
+            throw new UnsupportedOperationException("Found more than one function with method name \"" + descriptor.getName() + "\" in class \"" + descriptor.getFullClassName() + "\"");
+        }
+
+        this.bindingDefinitions = new HashMap<>();
+
+        for (Map.Entry<String, BindingInfo> entry : bindingInfos.entrySet()) {
+            this.bindingDefinitions.put(entry.getKey(), new BindingDefinition(entry.getKey(), entry.getValue()));
+        }
+    }
+
+    public Map<String, BindingDefinition> getBindingDefinitions() { return this.bindingDefinitions; }
+
+    public ParameterResolver getOverloadResolver() { return this.overloadResolver; }
+
+    public void execute(BindingDataStore dataStore) throws Exception {
+        Object retValue = this.overloadResolver.resolve(dataStore)
+                .orElseThrow(() -> new NoSuchMethodException("Cannot locate the method signature with the given input"))
+                .invoke(() -> this.containingClass.newInstance());
+        dataStore.setDataTargetValue(BindingDataStore.RETURN_NAME, retValue);
+    }
+
+    private Class<?> getContainingClass(String className, ClassLoaderProvider classLoaderProvider) throws ClassNotFoundException {
+        ClassLoader classLoader = classLoaderProvider.createClassLoader();
+        return Class.forName(className, true, classLoader);
+    }
+
+    private Class<?> containingClass;
+    private final ParameterResolver overloadResolver;
+    private final Map<String, BindingDefinition> bindingDefinitions;
+}

--- a/src/main/java/com/microsoft/azure/functions/worker/reflect/ClassLoaderProvider.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/reflect/ClassLoaderProvider.java
@@ -16,7 +16,7 @@ public interface ClassLoaderProvider {
     void addDirectory(File directory) throws MalformedURLException, IOException;
     
     /*
-     * Gets the class loader with the required search paths
+     * Create the class loader with the required search paths
      */
-    ClassLoader getClassLoader();
+    ClassLoader createClassLoader();
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/reflect/DefaultClassLoaderProvider.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/reflect/DefaultClassLoaderProvider.java
@@ -19,10 +19,10 @@ public class DefaultClassLoaderProvider implements ClassLoaderProvider {
   }
 
   /*
-   * @see com.microsoft.azure.functions.reflect.ClassLoaderProvider#getClassLoader()
+   * @see com.microsoft.azure.functions.reflect.ClassLoaderProvider#createClassLoader()
    */
   @Override
-  public ClassLoader getClassLoader() {
+  public ClassLoader createClassLoader() {
     URL[] urlsForClassLoader = new URL[urls.size()];
     urls.toArray(urlsForClassLoader);
 
@@ -59,6 +59,8 @@ public class DefaultClassLoaderProvider implements ClassLoaderProvider {
     WorkerLogManager.getSystemLogger().info("Loading file URL: " + url);    
 
     urls.add(url);
+
+
     addUrlToSystemClassLoader(url);
   }
 

--- a/src/main/java/com/microsoft/azure/functions/worker/reflect/EnhancedClassLoaderProvider.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/reflect/EnhancedClassLoaderProvider.java
@@ -1,0 +1,76 @@
+package com.microsoft.azure.functions.worker.reflect;
+
+import java.io.*;
+import java.net.*;
+import java.sql.Driver;
+import java.util.*;
+import java.util.concurrent.*;
+
+
+import com.microsoft.azure.functions.worker.*;
+
+public class EnhancedClassLoaderProvider implements ClassLoaderProvider {
+    public EnhancedClassLoaderProvider() {
+        urls = Collections.newSetFromMap(new ConcurrentHashMap<URL, Boolean>());
+    }
+
+    /*
+     * @see com.microsoft.azure.functions.reflect.ClassLoaderProvider#createClassLoader()
+     */
+    @Override
+    public ClassLoader createClassLoader() {
+        URL[] urlsForClassLoader = new URL[urls.size()];
+        urls.toArray(urlsForClassLoader);
+
+        URLClassLoader classLoader = new URLClassLoader(urlsForClassLoader);
+        loadDrivers(classLoader);
+        return classLoader;
+    }
+
+    private void loadDrivers(URLClassLoader classLoader) {
+        Thread.currentThread().setContextClassLoader(classLoader);
+        try {
+            ServiceLoader<Driver> loadedDrivers = ServiceLoader.load(Driver.class);
+            Iterator<Driver> driversIterator = loadedDrivers.iterator();
+            try {
+                while (driversIterator.hasNext()) {
+                    driversIterator.next();
+                }
+            } catch (Throwable t) {
+                // Do nothing
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(ClassLoader.getSystemClassLoader());
+        }
+    }
+
+    @Override
+    public void addDirectory(File directory) throws MalformedURLException, IOException {
+        if (!directory.exists()) {
+            return;
+        }
+
+        File[] jarFiles = directory.listFiles(new FileFilter() {
+            @Override
+            public boolean accept(File file) {
+                return file.isFile() && file.getName().endsWith(".jar");
+            }
+        });
+
+        for (File file : jarFiles) {
+            addUrl(file.toURI().toURL());
+        }
+    }
+
+    @Override
+    public void addUrl(URL url) throws IOException {
+        if (urls.contains(url)) {
+            return;
+        }
+
+        WorkerLogManager.getSystemLogger().info("Loading file URL: " + url);
+
+        urls.add(url);
+    }
+    private final Set<URL> urls;
+}

--- a/src/main/java/com/microsoft/azure/functions/worker/reflect/FactoryClassLoader.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/reflect/FactoryClassLoader.java
@@ -1,0 +1,13 @@
+package com.microsoft.azure.functions.worker.reflect;
+
+import org.apache.commons.lang3.SystemUtils;
+
+public class FactoryClassLoader {
+    public ClassLoaderProvider createClassLoaderProvider(){
+        if(SystemUtils.IS_JAVA_1_8) {
+            return new DefaultClassLoaderProvider();
+        } else {
+            return new EnhancedClassLoaderProvider();
+        }
+    }
+}

--- a/src/test/java/com/microsoft/azure/functions/worker/broker/tests/JavaMethodExecutorTests.java
+++ b/src/test/java/com/microsoft/azure/functions/worker/broker/tests/JavaMethodExecutorTests.java
@@ -14,29 +14,59 @@ import com.microsoft.azure.functions.worker.reflect.*;
 public class JavaMethodExecutorTests {
 	
 	@Test    
-    public void functionMethodLoadSucceeds() throws Exception {
+    public void functionMethodLoadSucceeds_8() throws Exception {
 		FunctionMethodDescriptor descriptor = new FunctionMethodDescriptor("testid", "TestHttpTrigger","com.microsoft.azure.functions.worker.broker.tests.TestFunctionsClass.TestHttpTrigger","TestFunctionsClass.jar");
 		Map<String, BindingInfo> bindings = new HashMap<>();
 		bindings.put("$return", BindingInfo.newBuilder().setDirection(BindingInfo.Direction.out).build());
-		JavaMethodExecutor executor = new JavaMethodExecutor(descriptor, bindings, new DefaultClassLoaderProvider());
+		JavaMethodExecutor executor = new FactoryJavaMethodExecutor().getJavaMethodExecutor(descriptor, bindings, new FactoryClassLoader().createClassLoaderProvider());
 		assertTrue(executor.getOverloadResolver().hasCandidates());
 		assertFalse(executor.getOverloadResolver().hasMultipleCandidates());
     }
 	
 	@Test(expected = NoSuchMethodException.class)   
-    public void functionMethod_doesnotexist_LoadFails() throws Exception {
+    public void functionMethod_doesnotexist_LoadFails_8() throws Exception {
 		FunctionMethodDescriptor descriptor = new FunctionMethodDescriptor("testid", "TestHttpTrigger1","com.microsoft.azure.functions.worker.broker.tests.TestFunctionsClass.TestHttpTrigger1","TestFunctionsClass.jar");
 		Map<String, BindingInfo> bindings = new HashMap<>();
 		bindings.put("$return", BindingInfo.newBuilder().setDirection(BindingInfo.Direction.out).build());
-		JavaMethodExecutor executor = new JavaMethodExecutor(descriptor, bindings, new DefaultClassLoaderProvider());	
+		JavaMethodExecutor executor = new FactoryJavaMethodExecutor().getJavaMethodExecutor(descriptor, bindings, new FactoryClassLoader().createClassLoaderProvider());
 		
     }
 	
 	@Test(expected = UnsupportedOperationException.class)   
-    public void functionMethod_DuplicateAnnotations_LoadFails() throws Exception {
+    public void functionMethod_DuplicateAnnotations_LoadFails_8() throws Exception {
 		FunctionMethodDescriptor descriptor = new FunctionMethodDescriptor("testid", "TestHttpTriggerOverload","com.microsoft.azure.functions.worker.broker.tests.TestFunctionsClass.TestHttpTriggerOverload","TestFunctionsClass.jar");
 		Map<String, BindingInfo> bindings = new HashMap<>();
 		bindings.put("$return", BindingInfo.newBuilder().setDirection(BindingInfo.Direction.out).build());
-		JavaMethodExecutor executor = new JavaMethodExecutor(descriptor, bindings, new DefaultClassLoaderProvider());	
+		JavaMethodExecutor executor = new FactoryJavaMethodExecutor().getJavaMethodExecutor(descriptor, bindings, new FactoryClassLoader().createClassLoaderProvider());
     }
+
+	@Test
+	public void functionMethodLoadSucceeds_11() throws Exception {
+		FunctionMethodDescriptor descriptor = new FunctionMethodDescriptor("testid", "TestHttpTrigger","com.microsoft.azure.functions.worker.broker.tests.TestFunctionsClass.TestHttpTrigger","TestFunctionsClass.jar");
+		Map<String, BindingInfo> bindings = new HashMap<>();
+		bindings.put("$return", BindingInfo.newBuilder().setDirection(BindingInfo.Direction.out).build());
+		System.setProperty("java.specification.version", "11");
+		JavaMethodExecutor executor = new FactoryJavaMethodExecutor().getJavaMethodExecutor(descriptor, bindings, new FactoryClassLoader().createClassLoaderProvider());
+		assertTrue(executor.getOverloadResolver().hasCandidates());
+		assertFalse(executor.getOverloadResolver().hasMultipleCandidates());
+	}
+
+	@Test(expected = NoSuchMethodException.class)
+	public void functionMethod_doesnotexist_LoadFails_11() throws Exception {
+		System.setProperty("java.specification.version", "11");
+		FunctionMethodDescriptor descriptor = new FunctionMethodDescriptor("testid", "TestHttpTrigger1","com.microsoft.azure.functions.worker.broker.tests.TestFunctionsClass.TestHttpTrigger1","TestFunctionsClass.jar");
+		Map<String, BindingInfo> bindings = new HashMap<>();
+		bindings.put("$return", BindingInfo.newBuilder().setDirection(BindingInfo.Direction.out).build());
+		JavaMethodExecutor executor = new FactoryJavaMethodExecutor().getJavaMethodExecutor(descriptor, bindings, new FactoryClassLoader().createClassLoaderProvider());
+
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void functionMethod_DuplicateAnnotations_LoadFails_11() throws Exception {
+		System.setProperty("java.specification.version", "11");
+		FunctionMethodDescriptor descriptor = new FunctionMethodDescriptor("testid", "TestHttpTriggerOverload","com.microsoft.azure.functions.worker.broker.tests.TestFunctionsClass.TestHttpTriggerOverload","TestFunctionsClass.jar");
+		Map<String, BindingInfo> bindings = new HashMap<>();
+		bindings.put("$return", BindingInfo.newBuilder().setDirection(BindingInfo.Direction.out).build());
+		JavaMethodExecutor executor = new FactoryJavaMethodExecutor().getJavaMethodExecutor(descriptor, bindings, new FactoryClassLoader().createClassLoaderProvider());
+	}
 }


### PR DESCRIPTION
This PR is for inital support for supporting Java 11 runtime, this PR includes.

- Add support for java11 testing pipeline.
- Fix the dev pipeline.
- Add support for java11.

Next, 
- Investigating updating classloader to lad last first, this should fix the dependency issue.
- Investigating the support for Modules.
- Support the two separate pipelines for java11 and java8.