### PR TITLE
Upgrade GRPC to 1.29.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,17 +76,17 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-protobuf</artifactId>
-			<version>1.20.0</version>
+			<version>1.29.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-stub</artifactId>
-			<version>1.20.0</version>
+			<version>1.29.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty</artifactId>
-			<version>1.20.0</version>
+			<version>1.29.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/src/main/java/com/microsoft/azure/functions/worker/JavaWorkerClient.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/JavaWorkerClient.java
@@ -22,7 +22,7 @@ import com.microsoft.azure.functions.rpc.messages.*;
 public class JavaWorkerClient implements AutoCloseable {
     public JavaWorkerClient(IApplication app) {
         WorkerLogManager.initialize(this, app.logToConsole());
-        ManagedChannelBuilder<?> chanBuilder = ManagedChannelBuilder.forAddress(app.getHost(), app.getPort()).usePlaintext(true);
+        ManagedChannelBuilder<?> chanBuilder = ManagedChannelBuilder.forAddress(app.getHost(), app.getPort()).usePlaintext();
         chanBuilder.maxInboundMessageSize(Integer.MAX_VALUE);
 
         this.channel = chanBuilder.build();


### PR DESCRIPTION
I create this PR for having a conversation. 

I update the version of the grpc-netty from 1.20.0  to grpc-netty-shaded 1.29.0.
It passes the all local test. I'd like to have CI validation on this repo. 

I change the interface of the `usePlainText(bool)`. It is deprecated for the new version. 
I'll investigate which library should be updated to latest.

## Related issue
https://github.com/Azure/azure-functions-java-worker/issues/365
https://github.com/Azure/azure-functions-java-worker/issues/354

