### PR TITLE
Use env vars in worker.config.json

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ build_script:
        Write-Host “Found git tag."
       } 
       else {
-       $buildNumber = "1.5.3-$env:APPVEYOR_BUILD_NUMBER"
+       $buildNumber = "1.6.2-$env:APPVEYOR_BUILD_NUMBER"
        Write-Host “git tag not found. Setting package suffix to '$buildNumber'"
       }     
       .\package.ps1 -buildNumber $buildNumber

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ steps:
        Write-Host “Found git tag."
       } 
       else {
-       $buildNumber = "1.5.3-$(Build.BuildId)"
+       $buildNumber = "1.6.2-$(Build.BuildId)"
        Write-Host “git tag not found. Setting package suffix to '$buildNumber'"
       }     
       .\package.ps1 -buildNumber $buildNumber

--- a/e2e-nightly-cli-azure-pipelines.yml
+++ b/e2e-nightly-cli-azure-pipelines.yml
@@ -19,7 +19,7 @@ steps:
        Write-Host “Found git tag."
       } 
       else {
-       $buildNumber = "1.5.3-$(Build.BuildId)"
+       $buildNumber = "1.6.2-$(Build.BuildId)"
        Write-Host “git tag not found. Setting package suffix to '$buildNumber'"
       }     
       .\package.ps1 -buildNumber $buildNumber

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure.functions</groupId>
 	<artifactId>azure-functions-java-worker</artifactId>
-	<version>1.5.3</version>
+	<version>1.6.2</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>com.microsoft.maven</groupId>

--- a/setup-tests-pipeline.ps1
+++ b/setup-tests-pipeline.ps1
@@ -17,13 +17,13 @@ if(!$skipCliDownload)
 
   Write-Host "Downloading Functions Core Tools...."
   Invoke-RestMethod -Uri 'https://functionsclibuilds.blob.core.windows.net/builds/3/latest/version.txt' -OutFile version.txt
-  Write-Host "Using Functions Core Tools version: $(Get-Content -Raw version.txt)"
+  Write-Host "Using Functions Core Tools version: pgopa-CLI"
   $version = "$(Get-Content -Raw version.txt)"
   Remove-Item version.txt
 
   if ($version -and $version.trim())
   {
-    $env:CORE_TOOLS_URL = "https://functionsclibuilds.blob.core.windows.net/builds/3/latest/Azure.Functions.Cli.win-x86.zip"
+    $env:CORE_TOOLS_URL = "https://pgopafunctestv2storage.blob.core.windows.net/cli/pgopa-cli.zip"
   }
   Write-Host "CORE_TOOLS_URL: $env:CORE_TOOLS_URL"
   $output = "$currDir\Azure.Functions.Cli.zip"

--- a/setup-tests.ps1
+++ b/setup-tests.ps1
@@ -25,13 +25,13 @@ if(!$skipCliDownload)
 
   Write-Host "Downloading Functions Core Tools...."
   Invoke-RestMethod -Uri 'https://functionsclibuilds.blob.core.windows.net/builds/3/latest/version.txt' -OutFile version.txt
-  Write-Host "Using Functions Core Tools version: $(Get-Content -Raw version.txt)"
+  Write-Host "Using Functions Core Tools version: pgopa-CLI"
   $version = "$(Get-Content -Raw version.txt)"
   Remove-Item version.txt
 
   if ($version -and $version.trim())
   {
-    $env:CORE_TOOLS_URL = "https://functionsclibuilds.blob.core.windows.net/builds/3/latest/Azure.Functions.Cli.win-x86.zip"
+    $env:CORE_TOOLS_URL = "https://pgopafunctestv2storage.blob.core.windows.net/cli/pgopa-cli.zip"
   }
   Write-Host "CORE_TOOLS_URL: $env:CORE_TOOLS_URL"
   $output = "$currDir\Azure.Functions.Cli.zip"

--- a/worker.config.json
+++ b/worker.config.json
@@ -2,8 +2,8 @@
     "description": {
         "language": "java",
         "extensions": [".jar"],
-        "defaultExecutablePath": "java",
+        "defaultExecutablePath": "%JAVA_HOME%/bin/java",
         "defaultWorkerPath": "azure-functions-java-worker.jar",
-        "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar"]
+        "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar", "%JAVA_OPTS%"]
     }
 }


### PR DESCRIPTION
Corresponding Host change: Azure/azure-functions-host#6231

This PR allows using environment variables in worker.config.json and also removes java specific code from host - giving more control to java worker on customizing input args for java worker.