### PR TITLE
fix: JAVA_OPTS doens't work

### DIFF
--- a/worker.config.json
+++ b/worker.config.json
@@ -4,6 +4,6 @@
         "extensions": [".jar"],
         "defaultExecutablePath": "%JAVA_HOME%/bin/java",
         "defaultWorkerPath": "azure-functions-java-worker.jar",
-        "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar", "%JAVA_OPTS%"]
+        "arguments": ["%JAVA_OPTS%", "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar"]
     }
 }

--- a/worker.config.json
+++ b/worker.config.json
@@ -4,6 +4,6 @@
         "extensions": [".jar"],
         "defaultExecutablePath": "%JAVA_HOME%/bin/java",
         "defaultWorkerPath": "azure-functions-java-worker.jar",
-        "arguments": ["%JAVA_OPTS%", "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar"]
+        "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar", "%JAVA_OPTS%", "%MESH_JAVA_OPTS%"]
     }
 }


### PR DESCRIPTION
Current worker config's `JAVA_OPTS` doesn't work.  The reason is, the first `arguments` finish with `-jar` that assumes, after this argument, jar file name should come. That means, if we specify an option with `JAVA_OPTS` it break the configuration.  The solution is swap the arguments order. I tested with mesh docker image with/without the option.

This work is related Distributed Tracing for Consumption Linux that requires new arguments for the java agent.

Until the release happens, I keep azure-functions-docker-private will copy this `worker.config.json` once this is released, I'll change it to use this commit. 

```json
{
    "description": {
        "language": "java",
        "extensions": [".jar"],
        "defaultExecutablePath": "%JAVA_HOME%/bin/java",
        "defaultWorkerPath": "azure-functions-java-worker.jar",
        "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar ", "%JAVA_OPTS%",]
    }
}
```