### PR TITLE
Release 1.8.1 with internal JAVA_OPTS argument

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ build_script:
        Write-Host “Found git tag."
       } 
       else {
-       $buildNumber = "1.8.0-$env:APPVEYOR_BUILD_NUMBER"
+       $buildNumber = "1.8.1-$env:APPVEYOR_BUILD_NUMBER"
        Write-Host “git tag not found. Setting package suffix to '$buildNumber'"
       }     
       .\package.ps1 -buildNumber $buildNumber

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ steps:
        Write-Host “Found git tag."
       } 
       else {
-       $buildNumber = "1.8.0-$(Build.BuildId)"
+       $buildNumber = "1.8.1-$(Build.BuildId)"
        Write-Host “git tag not found. Setting package suffix to '$buildNumber'"
       }     
       .\package-pipeline.ps1 -buildNumber $buildNumber

--- a/e2e-nightly-cli-azure-pipelines.yml
+++ b/e2e-nightly-cli-azure-pipelines.yml
@@ -19,7 +19,7 @@ steps:
        Write-Host “Found git tag."
       } 
       else {
-       $buildNumber = "1.8.0-$(Build.BuildId)"
+       $buildNumber = "1.8.1-$(Build.BuildId)"
        Write-Host “git tag not found. Setting package suffix to '$buildNumber'"
       }     
       .\package.ps1 -buildNumber $buildNumber

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure.functions</groupId>
 	<artifactId>azure-functions-java-worker</artifactId>
-	<version>1.8.0</version>
+	<version>1.8.1</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>com.microsoft.maven</groupId>


### PR DESCRIPTION
I bump the version for the release. 
This release includes 
* CI improvement https://github.com/Azure/azure-functions-java-worker/pull/402
* Update For Distributed Tracing https://github.com/Azure/azure-functions-java-worker/pull/411

Essentially, it is a change for adding %AZURE_FUNCTIONS_MESH_JAVA_OPTS% for `worker.config.json` for supporting a scenario of Distributed Tracing on mesh. 

That argument is usage for internal. Customers are not allowed to use. 