### PR TITLE
remove work lib logics

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
@@ -89,11 +89,10 @@ public class JavaFunctionBroker {
 	private void addSearchPathsToClassLoader(FunctionMethodDescriptor function) throws IOException {
 		URL jarUrl = new File(function.getJarPath()).toURI().toURL();
 		classLoaderProvider.addUrl(jarUrl);
-		if(function.getLibDirectory().isPresent()) {
-			registerWithClassLoaderProvider(function.getLibDirectory().get());
-		} else {
-			registerWithClassLoaderProviderWorkerLibOnly();
+		if(!function.getLibDirectory().isPresent()) {
+			throw new IllegalArgumentException("Customer lib directory is not set");
 		}
+		registerWithClassLoaderProvider(function.getLibDirectory().get());
 	}
 
 	void registerWithClassLoaderProviderWorkerLibOnly() {
@@ -120,23 +119,7 @@ public class JavaFunctionBroker {
 
 	void registerWithClassLoaderProvider(File libDirectory) {
 		try {
-			if(SystemUtils.IS_JAVA_1_8) {
-				String workerLibPath = System.getenv(Constants.FUNCTIONS_WORKER_DIRECTORY) + "/lib";
-				File workerLib = new File(workerLibPath);
-				verifyLibrariesExist (workerLib, workerLibPath);
-
-				if(Helper.isLoadAppLibsFirst()) {
-					// load client app jars first.
-					classLoaderProvider.addDirectory(libDirectory);
-					classLoaderProvider.addDirectory(workerLib);
-				} else {
-					// Default load worker jars first.
-					classLoaderProvider.addDirectory(workerLib);
-					classLoaderProvider.addDirectory(libDirectory);
-				}
-			} else {
-				classLoaderProvider.addDirectory(libDirectory);
-			}
+			classLoaderProvider.addDirectory(libDirectory);
 		} catch (Exception ex) {
 			ExceptionUtils.rethrow(ex);
 		}


### PR DESCRIPTION
Remove the logics for customer opt-in. Right now, customer is required to provide their own lib directory. 
Question to be clarified: one unit test failed due to the code change. Since this unit test didn't provide a it's lib directory. 
Proposed solution: copy the lib folder to target folder when build the package. This lib folder will work as a customer lib directory for unit tests. 