### PR TITLE
fix function name issue

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/worker/broker/EnhancedJavaMethodExecutorImpl.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/EnhancedJavaMethodExecutorImpl.java
@@ -23,7 +23,7 @@ public class EnhancedJavaMethodExecutorImpl implements JavaMethodExecutor {
         this.overloadResolver = new ParameterResolver();
 
         for (Method method : this.containingClass.getMethods()) {
-            if (method.getName().equals(descriptor.getMethodName())) {
+            if (method.getDeclaringClass().getName().equals(descriptor.getFullClassName()) && method.getName().equals(descriptor.getMethodName())) {
                 this.overloadResolver.addCandidate(method);
             }
         }

--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodExecutorImpl.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodExecutorImpl.java
@@ -24,7 +24,7 @@ public class JavaMethodExecutorImpl implements JavaMethodExecutor {
         this.overloadResolver = new ParameterResolver();
 
         for (Method method : this.containingClass.getMethods()) {
-            if (method.getName().equals(descriptor.getMethodName())) {
+            if (method.getDeclaringClass().getName().equals(descriptor.getFullClassName()) && method.getName().equals(descriptor.getMethodName())) {
                 this.overloadResolver.addCandidate(method);
             }
         }


### PR DESCRIPTION
Fix the issue that function cannot have same method name as any other method in it's parent class. 