### PR TITLE
Use a single classloader for java 11

### DIFF
--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/HttpEndToEndTests.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/HttpEndToEndTests.cs
@@ -46,5 +46,14 @@ namespace Azure.Functions.Java.Tests.E2E
             Assert.True(await Utilities.InvokeHttpTrigger("HttpTriggerJavaClassLoader", "?&name=Test", HttpStatusCode.OK, "Test"));
 
         }
+
+        [Fact]
+        public async void HttpTriggerJavaStatic()
+        {
+            await HttpTriggerTests("HttpTriggerJavaStatic1", "", HttpStatusCode.OK, "1");
+            await HttpTriggerTests("HttpTriggerJavaStatic2", "", HttpStatusCode.OK, "2");
+            await HttpTriggerTests("HttpTriggerJavaStatic1", "", HttpStatusCode.OK, "3");
+            await HttpTriggerTests("HttpTriggerJavaStatic2", "", HttpStatusCode.OK, "4");
+        }
     }
 }

--- a/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/HttpTriggerTests.java
+++ b/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/HttpTriggerTests.java
@@ -237,4 +237,32 @@ public class HttpTriggerTests {
             return request.createResponseBuilder(HttpStatus.OK).body("Hello, " + name).build();
         }
     }
+
+    private static int flag = 0;
+
+    @FunctionName("HttpTriggerJavaStatic1")
+    public HttpResponseMessage HttpTriggerJavaStatic1(
+            @HttpTrigger(
+                    name = "req",
+                    methods = {HttpMethod.GET, HttpMethod.POST},
+                    authLevel = AuthorizationLevel.ANONYMOUS)
+                    HttpRequestMessage<Optional<String>> request,
+            final ExecutionContext context) {
+        context.getLogger().info("Java HTTP trigger - static processed a request.");
+        flag++;
+        return request.createResponseBuilder(HttpStatus.OK).body(String.valueOf(flag)).build();
+    }
+
+    @FunctionName("HttpTriggerJavaStatic2")
+    public HttpResponseMessage HttpTriggerJavaStatic2(
+            @HttpTrigger(
+                    name = "req",
+                    methods = {HttpMethod.GET, HttpMethod.POST},
+                    authLevel = AuthorizationLevel.ANONYMOUS)
+                    HttpRequestMessage<Optional<String>> request,
+            final ExecutionContext context) {
+        context.getLogger().info("Java HTTP trigger - static processed a request.");
+        flag++;
+        return request.createResponseBuilder(HttpStatus.OK).body(String.valueOf(flag)).build();
+    }
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/reflect/EnhancedClassLoaderProvider.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/reflect/EnhancedClassLoaderProvider.java
@@ -19,12 +19,18 @@ public class EnhancedClassLoaderProvider implements ClassLoaderProvider {
      */
     @Override
     public ClassLoader createClassLoader() {
-        URL[] urlsForClassLoader = new URL[urls.size()];
-        urls.toArray(urlsForClassLoader);
-
-        URLClassLoader classLoader = new URLClassLoader(urlsForClassLoader);
-        loadDrivers(classLoader);
-        return classLoader;
+        if (classLoaderInstance == null) {
+            synchronized (lock) {
+                if (classLoaderInstance == null) {
+                    URL[] urlsForClassLoader = new URL[urls.size()];
+                    urls.toArray(urlsForClassLoader);
+                    URLClassLoader loader = new URLClassLoader(urlsForClassLoader);
+                    loadDrivers(loader);
+                    classLoaderInstance = loader;
+                }
+            }
+        }
+        return classLoaderInstance;
     }
 
     private void loadDrivers(URLClassLoader classLoader) {
@@ -73,4 +79,6 @@ public class EnhancedClassLoaderProvider implements ClassLoaderProvider {
         urls.add(url);
     }
     private final Set<URL> urls;
+    private final Object lock = new Object();
+    private static volatile URLClassLoader classLoaderInstance;
 }


### PR DESCRIPTION
Fixes
- For java 11 a synchronized singleton classloader will be used
- This fixes the issue - multiple instances of the static variable even though it's in the same class

Code changes
- Creating a singleton of the URLClassLoader which will be reused as necessary. 
- In order to handle synchronization across threads, the double checked locking with singleton is done.
- Using the volatile keyword to avoid any cache incoherence issues
- Test cases are updated to check if static variables are updated under the same instance

#412 