### PR TITLE
Use a single classloader for java 11 if environment variable is set

### DIFF
--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/HttpEndToEndTests.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/HttpEndToEndTests.cs
@@ -59,5 +59,19 @@ namespace Azure.Functions.Java.Tests.E2E
                 Assert.True(await Utilities.InvokeHttpTrigger("HttpTriggerJavaClassLoader", "?&name=Test", HttpStatusCode.InternalServerError, ""));
             }
         }
+
+        [Fact]
+        public async void HttpTriggerJavaStatic()
+        {
+            String value = Environment.GetEnvironmentVariable("FUNCTIONS_WORKER_JAVA_V3_SINGLE_CLASSLOADER");
+            String java_home = Environment.GetEnvironmentVariable("JAVA_HOME");
+            if (java_home.Contains("1.8") || (value != null && (value.ToLower().Equals("true") || value.ToLower().Equals("1"))))
+            {
+                await HttpTriggerTests("HttpTriggerJavaStatic1", "", HttpStatusCode.OK, "1");
+                await HttpTriggerTests("HttpTriggerJavaStatic2", "", HttpStatusCode.OK, "2");
+                await HttpTriggerTests("HttpTriggerJavaStatic1", "", HttpStatusCode.OK, "3");
+                await HttpTriggerTests("HttpTriggerJavaStatic2", "", HttpStatusCode.OK, "4");
+            }
+        }
     }
 }

--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Properties/launchSettings.json
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Properties/launchSettings.json
@@ -1,7 +1,10 @@
 {
   "profiles": {
     "Azure.Functions.Java.Tests.E2E": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "environmentVariables": {
+        "FUNCTIONS_WORKER_JAVA_V3_SINGLE_CLASSLOADER": "1"
+      }
     }
   }
 }

--- a/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/HttpTriggerTests.java
+++ b/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/HttpTriggerTests.java
@@ -237,4 +237,32 @@ public class HttpTriggerTests {
             return request.createResponseBuilder(HttpStatus.OK).body("Hello, " + name).build();
         }
     }
+
+    private static int flag = 0;
+
+    @FunctionName("HttpTriggerJavaStatic1")
+    public HttpResponseMessage HttpTriggerJavaStatic1(
+            @HttpTrigger(
+                    name = "req",
+                    methods = {HttpMethod.GET, HttpMethod.POST},
+                    authLevel = AuthorizationLevel.ANONYMOUS)
+                    HttpRequestMessage<Optional<String>> request,
+            final ExecutionContext context) {
+        context.getLogger().info("Java HTTP trigger - static processed a request.");
+        flag++;
+        return request.createResponseBuilder(HttpStatus.OK).body(String.valueOf(flag)).build();
+    }
+
+    @FunctionName("HttpTriggerJavaStatic2")
+    public HttpResponseMessage HttpTriggerJavaStatic2(
+            @HttpTrigger(
+                    name = "req",
+                    methods = {HttpMethod.GET, HttpMethod.POST},
+                    authLevel = AuthorizationLevel.ANONYMOUS)
+                    HttpRequestMessage<Optional<String>> request,
+            final ExecutionContext context) {
+        context.getLogger().info("Java HTTP trigger - static processed a request.");
+        flag++;
+        return request.createResponseBuilder(HttpStatus.OK).body(String.valueOf(flag)).build();
+    }
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/Constants.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/Constants.java
@@ -8,4 +8,5 @@ public final class Constants {
     public final static String TRIGGER_METADATA_DOLLAR_REQUEST_KEY = "$request";
     public final static String FUNCTIONS_WORKER_DIRECTORY = "FUNCTIONS_WORKER_DIRECTORY";
     public final static String FUNCTIONS_WORKER_JAVA_LOAD_APP_LIBS = "FUNCTIONS_WORKER_JAVA_LOAD_APP_LIBS";
+    public final static String FUNCTIONS_WORKER_JAVA_V3_SINGLE_CLASSLOADER = "FUNCTIONS_WORKER_JAVA_V3_SINGLE_CLASSLOADER";
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/Helper.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/Helper.java
@@ -6,4 +6,8 @@ public class Helper {
         String javaReverseLibLoading = System.getenv(Constants.FUNCTIONS_WORKER_JAVA_LOAD_APP_LIBS);
         return Util.isTrue(javaReverseLibLoading);
     }
+    public static boolean isCustomURLClassLoader() {
+        String customURLClassLoader = System.getenv(Constants.FUNCTIONS_WORKER_JAVA_V3_SINGLE_CLASSLOADER);
+        return Util.isTrue(customURLClassLoader);
+    }
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/reflect/EnhancedClassLoaderProvider.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/reflect/EnhancedClassLoaderProvider.java
@@ -19,9 +19,31 @@ public class EnhancedClassLoaderProvider implements ClassLoaderProvider {
      */
     @Override
     public ClassLoader createClassLoader() {
+        if(Helper.isCustomURLClassLoader()) {
+            return getURLClassLoaderInstance();
+        }else {
+            return createURLClassLoaderInstance();
+        }
+    }
+
+    /**
+     * Create and return a singleton URL classloader
+     * @return instance of URLClassLoader
+     */
+    private URLClassLoader getURLClassLoaderInstance() {
+        if (classLoaderInstance == null) {
+            synchronized (lock) {
+                if (classLoaderInstance == null) {
+                    classLoaderInstance = createURLClassLoaderInstance();
+                }
+            }
+        }
+        return classLoaderInstance;
+    }
+
+    private URLClassLoader createURLClassLoaderInstance(){
         URL[] urlsForClassLoader = new URL[urls.size()];
         urls.toArray(urlsForClassLoader);
-
         URLClassLoader classLoader = new URLClassLoader(urlsForClassLoader);
         loadDrivers(classLoader);
         return classLoader;
@@ -73,4 +95,6 @@ public class EnhancedClassLoaderProvider implements ClassLoaderProvider {
         urls.add(url);
     }
     private final Set<URL> urls;
+    private final Object lock = new Object();
+    private static volatile URLClassLoader classLoaderInstance;
 }


### PR DESCRIPTION
If the `FUNCTIONS_WORKER_JAVA_SINGLE_CLASSLOADER` environment variable is set to true then the following changes are made
- For java 11 a synchronized singleton classloader is created for usage 
- This fixes the issue - multiple instances of the static variable even though it's in the same class

#412 