### PR TITLE
Release 4.0.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
             Write-Host "Found git tag."
           }
           else {
-            $buildNumber="1.8.2-$(Build.BuildNumber)"
+            $buildNumber="4.0.0-$(Build.BuildNumber)"
             Write-Host "git tag not found. Setting package suffix to '$buildNumber'"
           }
           .\package-pipeline.ps1 -buildNumber $buildNumber

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure.functions</groupId>
 	<artifactId>azure-functions-java-worker</artifactId>
-	<version>1.8.2</version>
+	<version>4.0.0</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>com.microsoft.maven</groupId>


### PR DESCRIPTION
Release 4.0.0 has the following changes:
- For Java 11 - usage of a classloader singleton which is shared across the java worker 
- Remove the folder lib_worker_1.6.2 in java language worker. Java 8 it will not have default worker libraries