### PR TITLE
Release 1.9.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
         Write-Host "Found git tag."
       }
       else {
-        $buildNumber="3.0.0-$(Build.BuildNumber)"
+        $buildNumber="1.9.0-$(Build.BuildNumber)"
         Write-Host "git tag not found. Setting package suffix to '$buildNumber'"
       }
       .\package-pipeline.ps1 -buildNumber $buildNumber

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure.functions</groupId>
 	<artifactId>azure-functions-java-worker</artifactId>
-	<version>3.0.0</version>
+	<version>1.9.0</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>com.microsoft.maven</groupId>


### PR DESCRIPTION
Fixes the issue - multiple instances of the static variable even though it's in the same class: https://github.com/Azure/azure-functions-java-worker/issues/412
Including a environment variable `FUNCTIONS_WORKER_JAVA_SINGLE_CLASSLOADER`. If this variable is set to true then the following changes are made
- For java 11 a synchronized singleton classloader is created for usage 