### PR TITLE
Release 2.0.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
             Write-Host "Found git tag."
           }
           else {
-            $buildNumber="4.0.0-$(Build.BuildNumber)"
+            $buildNumber="2.0.0-$(Build.BuildNumber)"
             Write-Host "git tag not found. Setting package suffix to '$buildNumber'"
           }
           .\package-pipeline.ps1 -buildNumber $buildNumber

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure.functions</groupId>
 	<artifactId>azure-functions-java-worker</artifactId>
-	<version>4.0.0</version>
+	<version>2.0.0</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>com.microsoft.maven</groupId>


### PR DESCRIPTION
This release includes two break changes:

For java 11 a synchronized singleton classloader will be used. This fixes the issue Azure/Azure-Functions#1997
Java 8 stop supporting loading the worker jars, working jars are removed from java worker. Azure/Azure-Functions#1991