### PR TITLE
increase java worker start time out to 90s

### DIFF
--- a/worker.config.json
+++ b/worker.config.json
@@ -5,5 +5,8 @@
         "defaultExecutablePath": "%JAVA_HOME%/bin/java",
         "defaultWorkerPath": "azure-functions-java-worker.jar",
         "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
+    },
+    "processOptions": {
+        "ProcessStartupTimeout": "00:01:30"
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Increase Java worker startup time out to mitigate similar issues like https://portal.microsofticm.com/imp/v3/incidents/details/243957426/home

### Pull request checklist

* [X] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [X] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information