### PR TITLE
Kaibocai/blobtrigger test

### DIFF
--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Helpers/StorageHelpers.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Helpers/StorageHelpers.cs
@@ -135,13 +135,15 @@ namespace Azure.Functions.Java.Tests.E2E
             BlobContinuationToken blobContinuationToken = null;
             do
             {
+                if (!await cloudBlobContainer.ExistsAsync()) { continue; }
                 var results = await cloudBlobContainer.ListBlobsSegmentedAsync(null, blobContinuationToken);
                 // Get the value of the continuation token returned by the listing call.
                 blobContinuationToken = results.ContinuationToken;
                 foreach (IListBlobItem item in results.Results)
                 {
                     Console.WriteLine(item.Uri);
-                    CloudBlob cloudBlob = cloudBlobContainer.GetBlobReference(item.Uri.ToString());
+                    String blobName = System.IO.Path.GetFileName(item.Uri.AbsolutePath);
+                    CloudBlob cloudBlob = cloudBlobContainer.GetBlobReference(blobName);
                     await cloudBlob.DeleteIfExistsAsync();
                 }
             } while (blobContinuationToken != null); // Loop while the continuation token is not null.             

--- a/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/BlobTriggerTests.java
+++ b/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/BlobTriggerTests.java
@@ -23,7 +23,7 @@ public class BlobTriggerTests {
         @BlobOutput(name = "outputBlob", path = "test-output-java-new/{name}", dataType = "binary") OutputBinding<byte[]> outputBlob,
         final ExecutionContext context
     ) {
-        context.getLogger().info("Java Blob trigger function processed a blob.\n Name: " + fileName + "\n Size: " + triggerBlob.length + " Bytes");        
+        context.getLogger().info("Java Blob trigger function BlobTriggerToBlobTest processed a blob.\n Name: " + fileName + "\n Size: " + triggerBlob.length + " Bytes");
         outputBlob.setValue(inputBlob);
     }   
     
@@ -38,7 +38,7 @@ public class BlobTriggerTests {
         @BlobOutput(name = "outputBlob", path = "test-outputpojo-java/{name}") OutputBinding<TestBlobData> outputBlob,
         final ExecutionContext context
     ) {
-        context.getLogger().info("Java Blob trigger function processed a blob.\n Name: " + fileName + "\n Content: " + triggerBlobText.blobText);        
+        context.getLogger().info("Java Blob trigger function BlobTriggerPOJOTest processed a blob.\n Name: " + fileName + "\n Content: " + triggerBlobText.blobText);
         outputBlob.setValue(triggerBlobText);
     }
     
@@ -53,7 +53,7 @@ public class BlobTriggerTests {
         @BlobOutput(name = "outputBlob", path = "test-outputstring-java/{name}") OutputBinding<String> outputBlob,
         final ExecutionContext context
     ) {
-        context.getLogger().info("Java Blob trigger function processed a blob.\n Name: " + fileName + "\n Content: " + triggerBlobText);        
+        context.getLogger().info("Java Blob trigger function BlobTriggerStringTest processed a blob.\n Name: " + fileName + "\n Content: " + triggerBlobText);
         outputBlob.setValue(triggerBlobText);
     }
     


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Fixed failing delete old blob files issue in end to end tests

### Pull request checklist

* [X] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [X] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

old blob files that generated every end to end run are not deleted before this fix. 
![image](https://user-images.githubusercontent.com/89094811/140977345-c49da671-7895-4d85-9ebf-893411e0eba4.png)