### PR TITLE
Release 2.1.0-SNAPSHOT

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
             Write-Host "Found git tag."
           }
           else {
-            $buildNumber="2.0.0-$(Build.BuildNumber)"
+            $buildNumber="2.1.0-SNAPSHOT-$(Build.BuildNumber)"
             Write-Host "git tag not found. Setting package suffix to '$buildNumber'"
           }
           .\package-pipeline.ps1 -buildNumber $buildNumber

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.microsoft.azure.functions</groupId>
 	<artifactId>azure-functions-java-worker</artifactId>
-	<version>2.0.0</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<parent>
 		<groupId>com.microsoft.maven</groupId>


### PR DESCRIPTION
### Release notes

- Added retry context as part of execution context #418
- Fix bug - function with same name as any method in the Parent class will fail #451 
- Updated dependency from grpc-netty to use grpc-netty-shaded and adjusted the shading logic

#### Infrastructure and testing changes
- Updated extensionbundle version and core tools version for end to end tests
- Updated push condition for pre release feed
- Updated end to end tests for blog trigger and cosmos DB.