### PR TITLE
Remove hardcoded Windows env var for JAVA_HOME

### DIFF
--- a/worker.config.json
+++ b/worker.config.json
@@ -2,7 +2,7 @@
     "description": {
         "language": "java",
         "extensions": [".jar"],
-        "defaultExecutablePath": "%JAVA_HOME%/bin/java",
+        "defaultExecutablePath": "java",
         "defaultWorkerPath": "azure-functions-java-worker.jar",
         "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
     }


### PR DESCRIPTION
### Issue describing the changes in this PR

This fixes #421. The bug described in #421 also affects running Azure Functions on Linux and on Windows Subsystem for Linux, besides macOS.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)