### PR TITLE
update retry tests

### DIFF
--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Constants.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Constants.cs
@@ -57,6 +57,12 @@ namespace Azure.Functions.Java.Tests.E2E
         public static string OutputBinaryArrayManyQueueName = "test-binary-output-cardinality-many-array-java";
         public static string InputBinaryManyArrayEventHubQueueName = "test-binary-input-cardinality-many-array-java";
 
+        // EventHubs retry
+        public static string FixedDelayRetry = "fixed-retry";
+        public static string ExponentialBackoffRetry = "exponential-retry";
+        public static string RetryCount = "retry-count";
+        public static string MaxRetryCount = "max-retry-count";
+
         // Kafka
         public static string OutputStringOneKafkaQueueName = "test-kafka-output-cardinality-one-java";
 

--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/EventHubsEndToEndTests.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/EventHubsEndToEndTests.cs
@@ -229,7 +229,7 @@ namespace Azure.Functions.Java.Tests.E2E
                 await SetupQueue(Constants.MaxRetryCount);
 
                 // Need to setup EventHubs: test-input-java and test-output-java
-                await EventHubQueueHelpers.SendMessagesAsync(expectedEventId, Constants.MaxRetryCount, Constants.EventHubsConnectionStringSenderSetting);
+                await EventHubQueueHelpers.SendMessagesAsync(expectedEventId, Constants.MaxRetryCount, Constants.EventHubsConnectionStringSenderSetting2);
 
                 //Verify
                 var queueMessage = await StorageHelpers.ReadFromQueue(Constants.MaxRetryCount);

--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/EventHubsEndToEndTests.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/EventHubsEndToEndTests.cs
@@ -152,6 +152,96 @@ namespace Azure.Functions.Java.Tests.E2E
             }
         }
 
+        [Fact]
+        public async Task EventHubOutputFixedDelayRetry()
+        {
+            string expectedEventId = Guid.NewGuid().ToString();
+            try
+            {
+                await SetupQueue(Constants.FixedDelayRetry);
+
+                //send message to eventhub
+                await EventHubQueueHelpers.SendMessagesAsync(expectedEventId, Constants.FixedDelayRetry, Constants.EventHubsConnectionStringSenderSetting);
+
+                //Verify
+                var queueMessage = await StorageHelpers.ReadFromQueue(Constants.FixedDelayRetry);
+                Assert.Contains(expectedEventId, queueMessage);
+            }
+            finally
+            {
+                //Clear queue
+                await StorageHelpers.ClearQueue(Constants.FixedDelayRetry);
+            }
+        }
+
+        [Fact]
+        public async Task EventHubOutputExponentialBackoffRetry()
+        {
+            string expectedEventId = Guid.NewGuid().ToString();
+            try
+            {
+                await SetupQueue(Constants.ExponentialBackoffRetry);
+
+                // Need to setup EventHubs: test-input-java and test-output-java
+                await EventHubQueueHelpers.SendMessagesAsync(expectedEventId, Constants.ExponentialBackoffRetry, Constants.EventHubsConnectionStringSenderSetting);
+
+                //Verify
+                var queueMessage = await StorageHelpers.ReadFromQueue(Constants.ExponentialBackoffRetry);
+                Assert.Contains(expectedEventId, queueMessage);
+            }
+            finally
+            {
+                //Clear queue
+                await StorageHelpers.ClearQueue(Constants.ExponentialBackoffRetry);
+            }
+        }
+
+        [Fact]
+        public async Task EventHubTriggerRetryContextCount()
+        {
+            string expectedRetryCount = "1";
+            string expectedEventId = Guid.NewGuid().ToString();
+            try
+            {
+                await SetupQueue(Constants.RetryCount);
+
+                // Need to setup EventHubs: test-input-java and test-output-java
+                await EventHubQueueHelpers.SendMessagesAsync(expectedEventId, Constants.RetryCount, Constants.EventHubsConnectionStringSenderSetting);
+
+                //Verify
+                var queueMessage = await StorageHelpers.ReadFromQueue(Constants.RetryCount);
+                Assert.Equal(expectedRetryCount, queueMessage);
+            }
+            finally
+            {
+                //Clear queue
+                await StorageHelpers.ClearQueue(Constants.RetryCount);
+            }
+        }
+
+        [Fact]
+        public async Task EventHubTriggerMaxRetryContextCount()
+        {
+            string expectedMaxRetryCount = "3";
+            string expectedEventId = Guid.NewGuid().ToString();
+            try
+            {
+                await SetupQueue(Constants.MaxRetryCount);
+
+                // Need to setup EventHubs: test-input-java and test-output-java
+                await EventHubQueueHelpers.SendMessagesAsync(expectedEventId, Constants.MaxRetryCount, Constants.EventHubsConnectionStringSenderSetting);
+
+                //Verify
+                var queueMessage = await StorageHelpers.ReadFromQueue(Constants.MaxRetryCount);
+                Assert.Equal(expectedMaxRetryCount, queueMessage);
+            }
+            finally
+            {
+                //Clear queue
+                await StorageHelpers.ClearQueue(Constants.MaxRetryCount);
+            }
+        }
+
         private static async Task SetupQueue(string queueName)
         {
             //Clear queue

--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/HttpEndToEndTests.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/HttpEndToEndTests.cs
@@ -18,20 +18,21 @@ namespace Azure.Functions.Java.Tests.E2E
             _fixture = fixture;
         }
 
+        // TODO: remove commented test cases
         [Theory]
         [InlineData("HttpTriggerJava", "?&name=Test", HttpStatusCode.OK, "Test")]
         [InlineData("FontTypeSupport", "?&name=Test", HttpStatusCode.OK, "Test")]
         [InlineData("HttpTriggerJavaMetadata", "?&firstName=John&lastName=Doe", HttpStatusCode.OK, "JohnDoe")]
         [InlineData("HttpTriggerJavaThrows", "", HttpStatusCode.InternalServerError, "")]
         [InlineData("HttpTriggerJava", "", HttpStatusCode.BadRequest, "Please pass a name on the query string or in the request body")]
-        [InlineData("HttpExample-retry", "?&name=Test", HttpStatusCode.OK, "Test")]
-        [InlineData("HttpExample-runRetryFail", "", HttpStatusCode.InternalServerError, "")]
-        [InlineData("HttpExample-runExponentialBackoffRetryFail",  "", HttpStatusCode.InternalServerError, "")]
-        [InlineData("HttpExample-runExponentialBackoffRetry", "?&name=Test", HttpStatusCode.OK, "Test")]
+        //[InlineData("HttpExample-retry", "?&name=Test", HttpStatusCode.OK, "Test")]
+        //[InlineData("HttpExample-runRetryFail", "", HttpStatusCode.InternalServerError, "")]
+        //[InlineData("HttpExample-runExponentialBackoffRetryFail",  "", HttpStatusCode.InternalServerError, "")]
+        //[InlineData("HttpExample-runExponentialBackoffRetry", "?&name=Test", HttpStatusCode.OK, "Test")]
         [InlineData("HttpTriggerWaitMethod", "?&name=Test", HttpStatusCode.OK, "Test")]
         [InlineData("HttpTriggerNotifyMethod", "?&name=Test", HttpStatusCode.OK, "Test")]
-        [InlineData("HttpTriggerRetryContextCount", "?&name=Test", HttpStatusCode.OK, "1")]
-        [InlineData("HttpTriggerMaxRetryContextCount", "?&name=Test", HttpStatusCode.OK, "3")]
+        //[InlineData("HttpTriggerRetryContextCount", "?&name=Test", HttpStatusCode.OK, "1")]
+        //[InlineData("HttpTriggerMaxRetryContextCount", "?&name=Test", HttpStatusCode.OK, "3")]
         [InlineData("HttpTriggerJavaVersion", "", HttpStatusCode.OK, "HttpTriggerJavaVersion")]
         public async Task HttpTriggerTests(string functionName, string queryString, HttpStatusCode expectedStatusCode, string expectedErrorMessage)
         {

--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/HttpEndToEndTests.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/HttpEndToEndTests.cs
@@ -25,14 +25,10 @@ namespace Azure.Functions.Java.Tests.E2E
         [InlineData("HttpTriggerJavaMetadata", "?&firstName=John&lastName=Doe", HttpStatusCode.OK, "JohnDoe")]
         [InlineData("HttpTriggerJavaThrows", "", HttpStatusCode.InternalServerError, "")]
         [InlineData("HttpTriggerJava", "", HttpStatusCode.BadRequest, "Please pass a name on the query string or in the request body")]
-        //[InlineData("HttpExample-retry", "?&name=Test", HttpStatusCode.OK, "Test")]
         //[InlineData("HttpExample-runRetryFail", "", HttpStatusCode.InternalServerError, "")]
         //[InlineData("HttpExample-runExponentialBackoffRetryFail",  "", HttpStatusCode.InternalServerError, "")]
-        //[InlineData("HttpExample-runExponentialBackoffRetry", "?&name=Test", HttpStatusCode.OK, "Test")]
         [InlineData("HttpTriggerWaitMethod", "?&name=Test", HttpStatusCode.OK, "Test")]
         [InlineData("HttpTriggerNotifyMethod", "?&name=Test", HttpStatusCode.OK, "Test")]
-        //[InlineData("HttpTriggerRetryContextCount", "?&name=Test", HttpStatusCode.OK, "1")]
-        //[InlineData("HttpTriggerMaxRetryContextCount", "?&name=Test", HttpStatusCode.OK, "3")]
         [InlineData("HttpTriggerJavaVersion", "", HttpStatusCode.OK, "HttpTriggerJavaVersion")]
         public async Task HttpTriggerTests(string functionName, string queryString, HttpStatusCode expectedStatusCode, string expectedErrorMessage)
         {

--- a/endtoendtests/pom.xml
+++ b/endtoendtests/pom.xml
@@ -19,8 +19,6 @@
 		<functionAppName>azure-functions-java-endtoendtests</functionAppName>
 		<functionAppRegion>westus</functionAppRegion>
 		<functionResourceGroup>java-functions-group</functionResourceGroup>
-<!--		<stagingDirectory>${project.build.directory}/azure-functions/${functionAppName}</stagingDirectory>-->
-<!--		<allowTelemetry>false</allowTelemetry>-->
 	</properties>
 
 	<repositories>

--- a/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/EventHubTriggerTests.java
+++ b/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/EventHubTriggerTests.java
@@ -107,6 +107,63 @@ public class EventHubTriggerTests {
         output.setValue(messages[0]);
     }
 
+    public static int count = 1;
+    public static int countExp = 1;
+
+    @FunctionName("EventHubOutputFixedDelayRetry")
+    @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
+    public void EventHubOutputFixedDelayRetry(
+            @EventHubTrigger(name = "message", eventHubName = "fixed-retry", connection = "AzureWebJobsEventHubSender", cardinality = Cardinality.ONE) String message,
+            @QueueOutput(name = "output", queueName = "fixed-retry", connection = "AzureWebJobsStorage") OutputBinding<String> output,
+            final ExecutionContext context
+    ) throws Exception {
+        if(count<3) {
+            count ++;
+            throw new Exception("error");
+        }
+        context.getLogger().info("Java Event Hub Output function processed a message: " + message);
+        output.setValue(message);
+    }
+
+    @FunctionName("EventHubOutputExponentialBackoffRetry")
+    @ExponentialBackoffRetry(maxRetryCount = 3, minimumInterval = "00:00:01", maximumInterval = "00:00:03")
+    public void EventHubOutputExponentialBackoffRetry(
+            @EventHubTrigger(name = "message", eventHubName = "exponential-retry", connection = "AzureWebJobsEventHubSender", cardinality = Cardinality.ONE) String message,
+            @QueueOutput(name = "output", queueName = "exponential-retry", connection = "AzureWebJobsStorage") OutputBinding<String> output,
+            final ExecutionContext context) throws Exception {
+        if(countExp<3) {
+            countExp ++;
+            throw new Exception("error");
+        }
+        context.getLogger().info("Java Event Hub Output function processed a message: " + message);
+        output.setValue(message);
+    }
+
+    @FunctionName("EventHubTriggerRetryContextCount")
+    @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
+    public void EventHubTriggerRetryContextCount(
+            @EventHubTrigger(name = "message", eventHubName = "retry-count", connection = "AzureWebJobsEventHubSender", cardinality = Cardinality.ONE) String message,
+            @QueueOutput(name = "output", queueName = "retry-count", connection = "AzureWebJobsStorage") OutputBinding<String> output,
+            final ExecutionContext context
+    ) throws Exception {
+        if(context.getRetryContext().getRetrycount() == 0){
+            throw new RuntimeException("EventHubTriggerRetryContextCount error threw");
+        }
+        context.getLogger().info("Java Event Hub Output function processed a message: " + message);
+        output.setValue(String.valueOf(context.getRetryContext().getRetrycount()));
+    }
+
+    @FunctionName("EventHubTriggerMaxRetryContextCount")
+    @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
+    public void EventHubTriggerMaxRetryContextCount(
+            @EventHubTrigger(name = "message", eventHubName = "max-retry-count", connection = "AzureWebJobsEventHubSender", cardinality = Cardinality.ONE) String message,
+            @QueueOutput(name = "output", queueName = "max-retry-count", connection = "AzureWebJobsStorage") OutputBinding<String> output,
+            final ExecutionContext context
+    ) throws Exception {
+        context.getLogger().info("Java Event Hub Output function processed a message: " + message);
+        output.setValue(String.valueOf(context.getRetryContext().getMaxretrycount()));
+    }
+
     public static class SystemProperty {
       public String SequenceNumber;
       public String Offset;

--- a/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/EventHubTriggerTests.java
+++ b/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/EventHubTriggerTests.java
@@ -156,7 +156,7 @@ public class EventHubTriggerTests {
     @FunctionName("EventHubTriggerMaxRetryContextCount")
     @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
     public void EventHubTriggerMaxRetryContextCount(
-            @EventHubTrigger(name = "message", eventHubName = "max-retry-count", connection = "AzureWebJobsEventHubSender", cardinality = Cardinality.ONE) String message,
+            @EventHubTrigger(name = "message", eventHubName = "max-retry-count", connection = "AzureWebJobsEventHubSender_2", cardinality = Cardinality.ONE) String message,
             @QueueOutput(name = "output", queueName = "max-retry-count", connection = "AzureWebJobsStorage") OutputBinding<String> output,
             final ExecutionContext context
     ) throws Exception {

--- a/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/HttpTriggerTests.java
+++ b/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/HttpTriggerTests.java
@@ -134,35 +134,6 @@ public class HttpTriggerTests {
     public static int countFail = 1;
     public static int countExpFail = 1;
 
-    //TODO: remove this test, retry policy in GA only support Timer trigger and Eventhub Trigger,
-    // added replacement in eventhub test cases
-//    @FunctionName("HttpExample-retry")
-//    @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
-//    public HttpResponseMessage runRetry(
-//            @HttpTrigger(
-//                    name = "req",
-//                    methods = {HttpMethod.GET, HttpMethod.POST},
-//                    authLevel = AuthorizationLevel.ANONYMOUS)
-//                    HttpRequestMessage<Optional<String>> request,
-//            final ExecutionContext context) throws Exception {
-//        context.getLogger().info("Java HTTP trigger processed a request.");
-//
-//        if(count<3) {
-//            count ++;
-//            throw new Exception("error");
-//        }
-//
-//        // Parse query parameter
-//        final String query = request.getQueryParameters().get("name");
-//        final String name = request.getBody().orElse(query);
-//
-//        if (name == null) {
-//            return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a name on the query string or in the request body").build();
-//        } else {
-//            return request.createResponseBuilder(HttpStatus.OK).body(name).build();
-//        }
-//    }
-
     //TODO: write new cases for replacement
 //    @FunctionName("HttpExample-runRetryFail")
 //    @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
@@ -187,35 +158,6 @@ public class HttpTriggerTests {
 //            return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a name on the query string or in the request body").build();
 //        } else {
 //            return request.createResponseBuilder(HttpStatus.OK).body("Hello, " + name).build();
-//        }
-//    }
-
-    //TODO: remove this test, retry policy in GA only support Timer trigger and Eventhub Trigger,
-    // added replacement in eventhub test cases
-//    @FunctionName("HttpExample-runExponentialBackoffRetry")
-//    @ExponentialBackoffRetry(maxRetryCount = 3, minimumInterval = "00:00:01", maximumInterval = "00:00:03")
-//    public HttpResponseMessage runRetryExponentialBackoffRetry(
-//            @HttpTrigger(
-//                    name = "req",
-//                    methods = {HttpMethod.GET, HttpMethod.POST},
-//                    authLevel = AuthorizationLevel.ANONYMOUS)
-//                    HttpRequestMessage<Optional<String>> request,
-//            final ExecutionContext context) throws Exception {
-//        context.getLogger().info("Java HTTP trigger processed a request.");
-//
-//        if(countExp<3) {
-//            countExp ++;
-//            throw new Exception("error");
-//        }
-//
-//        // Parse query parameter
-//        final String query = request.getQueryParameters().get("name");
-//        final String name = request.getBody().orElse(query);
-//
-//        if (name == null) {
-//            return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a name on the query string or in the request body").build();
-//        } else {
-//            return request.createResponseBuilder(HttpStatus.OK).body(name).build();
 //        }
 //    }
 
@@ -309,42 +251,6 @@ public class HttpTriggerTests {
             return request.createResponseBuilder(HttpStatus.OK).body(name).build();
         }
     }
-
-    //TODO: remove this test, retry policy in GA only support Timer trigger and Eventhub Trigger,
-    // added replacement in eventhub test cases
-//    @FunctionName("HttpTriggerRetryContextCount")
-//    @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
-//    public HttpResponseMessage HttpTriggerRetryContext(
-//            @HttpTrigger(
-//                    name = "req",
-//                    methods = {HttpMethod.GET, HttpMethod.POST},
-//                    authLevel = AuthorizationLevel.ANONYMOUS)
-//                    HttpRequestMessage<Optional<String>> request,
-//            final ExecutionContext context) throws Exception {
-//        context.getLogger().info("Java HTTP trigger processed a request.");
-//
-//        if(context.getRetryContext().getRetrycount() == 0){
-//            throw new Exception("error");
-//        }
-//        return request.createResponseBuilder(HttpStatus.OK).body(String.valueOf(context.getRetryContext().getRetrycount())).build();
-//    }
-
-
-    //TODO: remove this test, retry policy in GA only support Timer trigger and Eventhub Trigger,
-    // added replacement in eventhub test cases
-//    @FunctionName("HttpTriggerMaxRetryContextCount")
-//    @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
-//    public HttpResponseMessage HttpTriggerMaxRetryContextCount(
-//            @HttpTrigger(
-//                    name = "req",
-//                    methods = {HttpMethod.GET, HttpMethod.POST},
-//                    authLevel = AuthorizationLevel.ANONYMOUS)
-//                    HttpRequestMessage<Optional<String>> request,
-//            final ExecutionContext context) throws Exception {
-//        context.getLogger().info("Java HTTP trigger processed a request.");
-//
-//        return request.createResponseBuilder(HttpStatus.OK).body(String.valueOf(context.getRetryContext().getMaxretrycount())).build();
-//    }
 
     @FunctionName("HttpTriggerJavaVersion")
     public static HttpResponseMessage HttpTriggerJavaVersion(

--- a/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/HttpTriggerTests.java
+++ b/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/HttpTriggerTests.java
@@ -134,111 +134,117 @@ public class HttpTriggerTests {
     public static int countFail = 1;
     public static int countExpFail = 1;
 
-    @FunctionName("HttpExample-retry")
-    @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
-    public HttpResponseMessage runRetry(
-            @HttpTrigger(
-                    name = "req",
-                    methods = {HttpMethod.GET, HttpMethod.POST},
-                    authLevel = AuthorizationLevel.ANONYMOUS)
-                    HttpRequestMessage<Optional<String>> request,
-            final ExecutionContext context) throws Exception {
-        context.getLogger().info("Java HTTP trigger processed a request.");
+    //TODO: remove this test, retry policy in GA only support Timer trigger and Eventhub Trigger,
+    // added replacement in eventhub test cases
+//    @FunctionName("HttpExample-retry")
+//    @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
+//    public HttpResponseMessage runRetry(
+//            @HttpTrigger(
+//                    name = "req",
+//                    methods = {HttpMethod.GET, HttpMethod.POST},
+//                    authLevel = AuthorizationLevel.ANONYMOUS)
+//                    HttpRequestMessage<Optional<String>> request,
+//            final ExecutionContext context) throws Exception {
+//        context.getLogger().info("Java HTTP trigger processed a request.");
+//
+//        if(count<3) {
+//            count ++;
+//            throw new Exception("error");
+//        }
+//
+//        // Parse query parameter
+//        final String query = request.getQueryParameters().get("name");
+//        final String name = request.getBody().orElse(query);
+//
+//        if (name == null) {
+//            return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a name on the query string or in the request body").build();
+//        } else {
+//            return request.createResponseBuilder(HttpStatus.OK).body(name).build();
+//        }
+//    }
 
-        if(count<3) {
-            count ++;
-            throw new Exception("error");
-        }
+    //TODO: write new cases for replacement
+//    @FunctionName("HttpExample-runRetryFail")
+//    @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
+//    public HttpResponseMessage runRetryFail(
+//            @HttpTrigger(
+//                    name = "req",
+//                    methods = {HttpMethod.GET, HttpMethod.POST},
+//                    authLevel = AuthorizationLevel.ANONYMOUS)
+//                    HttpRequestMessage<Optional<String>> request,
+//            final ExecutionContext context) throws Exception {
+//        context.getLogger().info("Java HTTP trigger processed a request.");
+//
+//        if(countFail<2) {
+//            throw new Exception("error");
+//        }
+//
+//        // Parse query parameter
+//        final String query = request.getQueryParameters().get("name");
+//        final String name = request.getBody().orElse(query);
+//
+//        if (name == null) {
+//            return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a name on the query string or in the request body").build();
+//        } else {
+//            return request.createResponseBuilder(HttpStatus.OK).body("Hello, " + name).build();
+//        }
+//    }
 
-        // Parse query parameter
-        final String query = request.getQueryParameters().get("name");
-        final String name = request.getBody().orElse(query);
+    //TODO: remove this test, retry policy in GA only support Timer trigger and Eventhub Trigger,
+    // added replacement in eventhub test cases
+//    @FunctionName("HttpExample-runExponentialBackoffRetry")
+//    @ExponentialBackoffRetry(maxRetryCount = 3, minimumInterval = "00:00:01", maximumInterval = "00:00:03")
+//    public HttpResponseMessage runRetryExponentialBackoffRetry(
+//            @HttpTrigger(
+//                    name = "req",
+//                    methods = {HttpMethod.GET, HttpMethod.POST},
+//                    authLevel = AuthorizationLevel.ANONYMOUS)
+//                    HttpRequestMessage<Optional<String>> request,
+//            final ExecutionContext context) throws Exception {
+//        context.getLogger().info("Java HTTP trigger processed a request.");
+//
+//        if(countExp<3) {
+//            countExp ++;
+//            throw new Exception("error");
+//        }
+//
+//        // Parse query parameter
+//        final String query = request.getQueryParameters().get("name");
+//        final String name = request.getBody().orElse(query);
+//
+//        if (name == null) {
+//            return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a name on the query string or in the request body").build();
+//        } else {
+//            return request.createResponseBuilder(HttpStatus.OK).body(name).build();
+//        }
+//    }
 
-        if (name == null) {
-            return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a name on the query string or in the request body").build();
-        } else {
-            return request.createResponseBuilder(HttpStatus.OK).body(name).build();
-        }
-    }
-
-    @FunctionName("HttpExample-runRetryFail")
-    @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
-    public HttpResponseMessage runRetryFail(
-            @HttpTrigger(
-                    name = "req",
-                    methods = {HttpMethod.GET, HttpMethod.POST},
-                    authLevel = AuthorizationLevel.ANONYMOUS)
-                    HttpRequestMessage<Optional<String>> request,
-            final ExecutionContext context) throws Exception {
-        context.getLogger().info("Java HTTP trigger processed a request.");
-
-        if(countFail<2) {
-            throw new Exception("error");
-        }
-
-        // Parse query parameter
-        final String query = request.getQueryParameters().get("name");
-        final String name = request.getBody().orElse(query);
-
-        if (name == null) {
-            return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a name on the query string or in the request body").build();
-        } else {
-            return request.createResponseBuilder(HttpStatus.OK).body("Hello, " + name).build();
-        }
-    }
-
-    @FunctionName("HttpExample-runExponentialBackoffRetry")
-    @ExponentialBackoffRetry(maxRetryCount = 3, minimumInterval = "00:00:01", maximumInterval = "00:00:03")
-    public HttpResponseMessage runRetryExponentialBackoffRetry(
-            @HttpTrigger(
-                    name = "req",
-                    methods = {HttpMethod.GET, HttpMethod.POST},
-                    authLevel = AuthorizationLevel.ANONYMOUS)
-                    HttpRequestMessage<Optional<String>> request,
-            final ExecutionContext context) throws Exception {
-        context.getLogger().info("Java HTTP trigger processed a request.");
-
-        if(countExp<3) {
-            countExp ++;
-            throw new Exception("error");
-        }
-
-        // Parse query parameter
-        final String query = request.getQueryParameters().get("name");
-        final String name = request.getBody().orElse(query);
-
-        if (name == null) {
-            return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a name on the query string or in the request body").build();
-        } else {
-            return request.createResponseBuilder(HttpStatus.OK).body(name).build();
-        }
-    }
-
-    @FunctionName("HttpExample-runExponentialBackoffRetryFail")
-    @ExponentialBackoffRetry(maxRetryCount = 3, minimumInterval = "00:00:01", maximumInterval = "00:00:03")
-    public HttpResponseMessage runRetryExponentialBackoffRetryFail(
-            @HttpTrigger(
-                    name = "req",
-                    methods = {HttpMethod.GET, HttpMethod.POST},
-                    authLevel = AuthorizationLevel.ANONYMOUS)
-                    HttpRequestMessage<Optional<String>> request,
-            final ExecutionContext context) throws Exception {
-        context.getLogger().info("Java HTTP trigger processed a request.");
-
-        if(countExpFail<2) {
-            throw new Exception("error");
-        }
-
-        // Parse query parameter
-        final String query = request.getQueryParameters().get("name");
-        final String name = request.getBody().orElse(query);
-
-        if (name == null) {
-            return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a name on the query string or in the request body").build();
-        } else {
-            return request.createResponseBuilder(HttpStatus.OK).body("Hello, " + name).build();
-        }
-    }
+    //TODO: write new cases for replacement
+//    @FunctionName("HttpExample-runExponentialBackoffRetryFail")
+//    @ExponentialBackoffRetry(maxRetryCount = 3, minimumInterval = "00:00:01", maximumInterval = "00:00:03")
+//    public HttpResponseMessage runRetryExponentialBackoffRetryFail(
+//            @HttpTrigger(
+//                    name = "req",
+//                    methods = {HttpMethod.GET, HttpMethod.POST},
+//                    authLevel = AuthorizationLevel.ANONYMOUS)
+//                    HttpRequestMessage<Optional<String>> request,
+//            final ExecutionContext context) throws Exception {
+//        context.getLogger().info("Java HTTP trigger processed a request.");
+//
+//        if(countExpFail<2) {
+//            throw new Exception("error");
+//        }
+//
+//        // Parse query parameter
+//        final String query = request.getQueryParameters().get("name");
+//        final String name = request.getBody().orElse(query);
+//
+//        if (name == null) {
+//            return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a name on the query string or in the request body").build();
+//        } else {
+//            return request.createResponseBuilder(HttpStatus.OK).body("Hello, " + name).build();
+//        }
+//    }
 
     private static int flag = 0;
 
@@ -304,37 +310,41 @@ public class HttpTriggerTests {
         }
     }
 
-    @FunctionName("HttpTriggerRetryContextCount")
-    @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
-    public HttpResponseMessage HttpTriggerRetryContext(
-            @HttpTrigger(
-                    name = "req",
-                    methods = {HttpMethod.GET, HttpMethod.POST},
-                    authLevel = AuthorizationLevel.ANONYMOUS)
-                    HttpRequestMessage<Optional<String>> request,
-            final ExecutionContext context) throws Exception {
-        context.getLogger().info("Java HTTP trigger processed a request.");
+    //TODO: remove this test, retry policy in GA only support Timer trigger and Eventhub Trigger,
+    // added replacement in eventhub test cases
+//    @FunctionName("HttpTriggerRetryContextCount")
+//    @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
+//    public HttpResponseMessage HttpTriggerRetryContext(
+//            @HttpTrigger(
+//                    name = "req",
+//                    methods = {HttpMethod.GET, HttpMethod.POST},
+//                    authLevel = AuthorizationLevel.ANONYMOUS)
+//                    HttpRequestMessage<Optional<String>> request,
+//            final ExecutionContext context) throws Exception {
+//        context.getLogger().info("Java HTTP trigger processed a request.");
+//
+//        if(context.getRetryContext().getRetrycount() == 0){
+//            throw new Exception("error");
+//        }
+//        return request.createResponseBuilder(HttpStatus.OK).body(String.valueOf(context.getRetryContext().getRetrycount())).build();
+//    }
 
-        if(context.getRetryContext().getRetrycount() == 0){
-            throw new Exception("error");
-        }
-        return request.createResponseBuilder(HttpStatus.OK).body(String.valueOf(context.getRetryContext().getRetrycount())).build();
-    }
 
-
-    @FunctionName("HttpTriggerMaxRetryContextCount")
-    @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
-    public HttpResponseMessage HttpTriggerMaxRetryContextCount(
-            @HttpTrigger(
-                    name = "req",
-                    methods = {HttpMethod.GET, HttpMethod.POST},
-                    authLevel = AuthorizationLevel.ANONYMOUS)
-                    HttpRequestMessage<Optional<String>> request,
-            final ExecutionContext context) throws Exception {
-        context.getLogger().info("Java HTTP trigger processed a request.");
-
-        return request.createResponseBuilder(HttpStatus.OK).body(String.valueOf(context.getRetryContext().getMaxretrycount())).build();
-    }
+    //TODO: remove this test, retry policy in GA only support Timer trigger and Eventhub Trigger,
+    // added replacement in eventhub test cases
+//    @FunctionName("HttpTriggerMaxRetryContextCount")
+//    @FixedDelayRetry(maxRetryCount = 3, delayInterval = "00:00:05")
+//    public HttpResponseMessage HttpTriggerMaxRetryContextCount(
+//            @HttpTrigger(
+//                    name = "req",
+//                    methods = {HttpMethod.GET, HttpMethod.POST},
+//                    authLevel = AuthorizationLevel.ANONYMOUS)
+//                    HttpRequestMessage<Optional<String>> request,
+//            final ExecutionContext context) throws Exception {
+//        context.getLogger().info("Java HTTP trigger processed a request.");
+//
+//        return request.createResponseBuilder(HttpStatus.OK).body(String.valueOf(context.getRetryContext().getMaxretrycount())).build();
+//    }
 
     @FunctionName("HttpTriggerJavaVersion")
     public static HttpResponseMessage HttpTriggerJavaVersion(


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Due to azure functions remove support for retry on Http trigger from preview to GA, the end2end test cases in java that using Http trigger for retry test will fail. In GA, only timer trigger and eventhub trigger are supported. This pr includes:

1. remove test cases for Http trigger with retry
2. add test cases for eventhub trigger with retry

### Pull request checklist

* [X] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information