### PR TITLE
Clean unused maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.0.0-M2</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>enforce-maven</id>
@@ -295,7 +295,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.2.2</version>
 				<executions>
 					<execution>
 						<phase>test-compile</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
 			</plugin>
 
 			<!-- This plugin adds generated grpc class files to source directory -->
-			<plugin>
+<!-- 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
 				<version>1.8</version>
@@ -325,7 +325,7 @@
 						</configuration>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin> -->
 
 
 			<!-- This plugin helps to config and run unit tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -306,28 +306,6 @@
 				</executions>
 			</plugin>
 
-			<!-- This plugin adds generated grpc class files to source directory -->
-<!-- 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>1.8</version>
-				<executions>
-					<execution>
-						<id>add-source</id>
-						<phase>generate-sources</phase>
-						<goals>
-							<goal>add-source</goal>
-						</goals>
-						<configuration>
-							<sources>
-								<source>${project.build.directory}/generated-sources/protobuf/java/</source>
-							</sources>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin> -->
-
-
 			<!-- This plugin helps to config and run unit tests -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

build-helper-maven-plugin is doing the repeated work which has already be done by protobuf-maven-plugin -- add generated grpc java file to source directory.


### Pull request checklist

* [X] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information