### PR TITLE
V3 - Update worker.config.json to include profiles that enable and disable app insights 

### DIFF
--- a/worker.config.json
+++ b/worker.config.json
@@ -5,5 +5,37 @@
         "defaultExecutablePath": "%JAVA_HOME%/bin/java",
         "defaultWorkerPath": "azure-functions-java-worker.jar",
         "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
-    }
+    },
+    "profiles":
+    [
+        {
+            "profileName":"AppInsightsConsumptionOptOut",
+            "conditions":[
+                {"conditionType":"environment","conditionName":"languageWorkers:java:arguments","conditionExpression":"-DaiAgentOptOut"},
+                {"conditionType":"hostProperty","conditionName":"sku","conditionExpression":"Dynamic"}
+            ],
+            "description":{
+                "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
+            }
+        },
+        {
+            "profileName":"AppInsightsConsumption",
+            "conditions":[
+                {"conditionType":"hostProperty","conditionName":"sku","conditionExpression":"Dynamic"}
+            ],
+            "description":{
+                "arguments":["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -javaagent:\"{workerDirectoryPath}/agent/applicationinsights-agent.jar\" -DLazySetOptIn=false -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
+            }
+        },
+        {
+            "profileName":"AppInsightsEnabledDedicated",
+            "conditions":[
+                {"conditionType":"environment","conditionName":"APPLICATIONINSIGHTS_ENABLE_AGENT","conditionExpression":"true"},
+                {"conditionType":"hostProperty","conditionName":"sku","conditionExpression":"(Standard|ElasticPremium)"}
+            ],
+            "description":{
+                "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -javaagent:\"{workerDirectoryPath}/agent/applicationinsights-agent.jar\" -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
+            }
+        }
+    ]
 }

--- a/worker.config.json
+++ b/worker.config.json
@@ -40,7 +40,7 @@
         {
             "profileName":"AppInsightsNoPlaceholder",
             "conditions":[
-                {"conditionType":"environment","conditionName":"APPLICATIONINSIGHTS_ENABLE_AGENT","conditionExpression":"true"}
+                {"conditionType":"environment","conditionName":"APPLICATIONINSIGHTS_ENABLE_AGENT","conditionExpression":"(?i)true$"}
             ],
             "description":{
                 "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -javaagent:\"{workerDirectoryPath}/agent/applicationinsights-agent.jar\" -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]

--- a/worker.config.json
+++ b/worker.config.json
@@ -21,7 +21,7 @@
         {
             "profileName":"AppInsightsOptOutLinux",
             "conditions":[
-                {"conditionType":"environment","conditionName":"languageWorkers_java_arguments","conditionExpression":".*-DaiAgentOptOut.*"},
+                {"conditionType":"environment","conditionName":"languageWorkers__java__arguments","conditionExpression":".*-DaiAgentOptOut.*"},
                 {"conditionType":"hostProperty","conditionName":"platform","conditionExpression":"LINUX"}
             ],
             "description":{

--- a/worker.config.json
+++ b/worker.config.json
@@ -9,29 +9,38 @@
     "profiles":
     [
         {
-            "profileName":"AppInsightsConsumptionOptOut",
+            "profileName":"AppInsightsOptOutWindows",
             "conditions":[
-                {"conditionType":"environment","conditionName":"languageWorkers:java:arguments","conditionExpression":"-DaiAgentOptOut"},
-                {"conditionType":"hostProperty","conditionName":"sku","conditionExpression":"Dynamic"}
+                {"conditionType":"environment","conditionName":"languageWorkers:java:arguments","conditionExpression":".*-DaiAgentOptOut.*"},
+                {"conditionType":"hostProperty","conditionName":"platform","conditionExpression":"WINDOWS"}
             ],
             "description":{
                 "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
             }
         },
         {
-            "profileName":"AppInsightsConsumption",
+            "profileName":"AppInsightsOptOutLinux",
             "conditions":[
-                {"conditionType":"hostProperty","conditionName":"sku","conditionExpression":"Dynamic"}
+                {"conditionType":"environment","conditionName":"languageWorkers_java_arguments","conditionExpression":".*-DaiAgentOptOut.*"},
+                {"conditionType":"hostProperty","conditionName":"platform","conditionExpression":"LINUX"}
+            ],
+            "description":{
+                "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
+            }
+        },
+        {
+            "profileName":"AppInsightsPlaceholder",
+            "conditions":[
+                {"conditionType":"environment","conditionName":"WEBSITE_PLACEHOLDER_MODE","conditionExpression":"1"}
             ],
             "description":{
                 "arguments":["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -javaagent:\"{workerDirectoryPath}/agent/applicationinsights-agent.jar\" -DLazySetOptIn=false -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
             }
         },
         {
-            "profileName":"AppInsightsEnabledDedicated",
+            "profileName":"AppInsightsNoPlaceholder",
             "conditions":[
-                {"conditionType":"environment","conditionName":"APPLICATIONINSIGHTS_ENABLE_AGENT","conditionExpression":"true"},
-                {"conditionType":"hostProperty","conditionName":"sku","conditionExpression":"(Standard|ElasticPremium)"}
+                {"conditionType":"environment","conditionName":"APPLICATIONINSIGHTS_ENABLE_AGENT","conditionExpression":"true"}
             ],
             "description":{
                 "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -javaagent:\"{workerDirectoryPath}/agent/applicationinsights-agent.jar\" -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]


### PR DESCRIPTION
Profiles are configured in worker config to enable and disable app insights.

resolves #585

Profiles: https://github.com/Azure/azure-functions-host/pull/8365

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information