### PR TITLE
[Bug Fix]missing system logs in ksuto

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/worker/WorkerLogManager.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/WorkerLogManager.java
@@ -69,6 +69,7 @@ public class WorkerLogManager {
     private boolean logToConsole;
     private final Logger emptyLogger, systemLogger, hostLogger;
     private final static WorkerLogManager INSTANCE = new WorkerLogManager();
+    public final static String SYSTEM_LOG_PREFIX = "azure_functions_java_worker";
 }
 
 class SystemLoggerListener extends Handler {

--- a/src/main/java/com/microsoft/azure/functions/worker/handler/RpcLogHandler.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/handler/RpcLogHandler.java
@@ -18,6 +18,18 @@ public class RpcLogHandler extends OutboundMessageHandler<RpcLog.Builder> {
 
     private static RpcLog.Builder generateRpcLog(LogRecord record, String invocationId) {
         RpcLog.Builder log = RpcLog.newBuilder();
+        /**
+         * Check if the logging namespace belongs to system logsq, invocation log should be categorized to user type (default), others should
+         * be categorized to system type.
+         *
+         *              local_console   customer_app_insight    functions_kusto_table
+         * system_log   false,           false,                   true
+         * user_log     true,            true,                    false
+         */
+        if (invocationId == null){
+            log.setLogCategory(RpcLog.RpcLogCategory.System);
+            log.setCategory(WorkerLogManager.SYSTEM_LOG_PREFIX);
+        }
         Optional.ofNullable(invocationId).ifPresent(log::setInvocationId);
         Optional.ofNullable(record.getLoggerName()).ifPresent(log::setCategory);
         Optional.ofNullable(mapLogLevel(record.getLevel())).ifPresent(log::setLevel);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Fixed issue some logs are missing in kusto logs. 
Java worker is not set [RpcLogCategory ](https://github.com/Azure/azure-functions-language-worker-protobuf/blob/ffbd3ddb07c4332b54bf8d40a4abc454661bfcbd/src/proto/FunctionRpc.proto#L540), by default it is set to user type, which will be logged to console as well as cx app insight if invocationId is present. It will not log to kusto. All java worker Rpclog are user type since we didn't set it explicitly, which causing those logs are not logged to kusto. For example: [FunctionLoaderRequest log](https://github.com/Azure/azure-functions-java-worker/blob/be760addee600a8466bef5a04e3e26f87c26c97d/src/main/java/com/microsoft/azure/functions/worker/handler/FunctionLoadRequestHandler.java#L29), [WorkerStatusRequestHandler Log](https://github.com/Azure/azure-functions-java-worker/blob/be760addee600a8466bef5a04e3e26f87c26c97d/src/main/java/com/microsoft/azure/functions/worker/handler/WorkerStatusRequestHandler.java#L15), etc. They all are user type but not have invocationId, they will be discarded from host side. 
We should set them to system type, so they will be log to kusto



         Check if the logging namespace belongs to system log, invocation log should be categorized to user type (default), others should
         be categorized to system type.
         
                       local_console   customer_app_insight    functions_kusto_table
          system_log   false,           false,                   true
          user_log     true,            true,                    false


Host process rpclog with type user can be found https://github.com/Azure/azure-functions-host/blob/1347a2b1c10fdbd040be5f16f91d365ad69c1466/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs#L713, noticed it's discard any log without invocationId here https://github.com/Azure/azure-functions-host/blob/1347a2b1c10fdbd040be5f16f91d365ad69c1466/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs#L717. 

Host process rpclog with type system can be found https://github.com/Azure/azure-functions-host/blob/1347a2b1c10fdbd040be5f16f91d365ad69c1466/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs#L751

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information