### PR TITLE
[Bug Fix] classloader not correct for java11 static fields

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/worker/broker/EnhancedJavaMethodExecutorImpl.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/EnhancedJavaMethodExecutorImpl.java
@@ -60,7 +60,7 @@ public class EnhancedJavaMethodExecutorImpl implements JavaMethodExecutor {
     }
 
     private Class<?> getContainingClass(String className) throws ClassNotFoundException {
-        return Class.forName(className, true, this.classLoader);
+        return Class.forName(className, false, this.classLoader);
     }
 
     private final Class<?> containingClass;


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This pr fix the issue that classloaders are different when load static and non-static fields/blocks. 
Samples can be found https://github.com/Azure/azure-functions-java-worker/issues/589

### Pull request checklist

* [X] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information