### PR TITLE
enhance rpc exception in app inisght sdk

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodInvokeInfo.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodInvokeInfo.java
@@ -2,7 +2,10 @@ package com.microsoft.azure.functions.worker.broker;
 
 import java.lang.reflect.*;
 import java.util.*;
+import java.util.logging.Level;
 
+import com.microsoft.azure.functions.worker.WorkerLogManager;
+import com.microsoft.azure.functions.worker.exception.UserFunctionException;
 import org.apache.commons.lang3.exception.*;
 
 interface InstanceSupplier {
@@ -18,8 +21,12 @@ class JavaMethodInvokeInfo {
 
     Object invoke(InstanceSupplier instanceSupplier) throws Exception {
         Object instance = Modifier.isStatic(this.m.getModifiers()) ? null : instanceSupplier.get();
+
         try {
             return this.m.invoke(instance, this.args);
+        } catch (InvocationTargetException ex) {
+            WorkerLogManager.getSystemLogger().severe(String.format("exception happens in customer function: %s : %s", this.m.getName(), ex.getMessage()));
+            return ExceptionUtils.rethrow(new UserFunctionException(this.m.getName(), ex.getCause()));
         } catch (Exception ex) {
             return ExceptionUtils.rethrow(ex);
         }

--- a/src/main/java/com/microsoft/azure/functions/worker/exception/UserFunctionException.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/exception/UserFunctionException.java
@@ -1,0 +1,25 @@
+package com.microsoft.azure.functions.worker.exception;
+
+public class UserFunctionException extends WorkerBaseException{
+
+    private static final String message = "exception happens in customer function: ";
+    public UserFunctionException() {
+        super();
+    }
+
+    public UserFunctionException(String message) {
+        super(message);
+    }
+
+    public UserFunctionException(String input, Throwable cause) {
+        super(message + input, cause);
+    }
+
+    public UserFunctionException(Throwable cause) {
+        super(cause);
+    }
+
+    public UserFunctionException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/com/microsoft/azure/functions/worker/exception/WorkerBaseException.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/exception/WorkerBaseException.java
@@ -1,0 +1,23 @@
+package com.microsoft.azure.functions.worker.exception;
+
+public class WorkerBaseException extends RuntimeException{
+    public WorkerBaseException() {
+        super();
+    }
+
+    public WorkerBaseException(String message) {
+        super(message);
+    }
+
+    public WorkerBaseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public WorkerBaseException(Throwable cause) {
+        super(cause);
+    }
+
+    public WorkerBaseException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves [[#issue_for_this_pr](https://github.com/Azure/azure-functions-language-worker-protobuf/pull/70)](https://github.com/Azure/azure-functions-host/issues/4296)
More info can be found: https://github.com/Azure/azure-functions-language-worker-protobuf/pull/70

Currently all exception happen in cx code are warped into RPCException and showing up in app insight as 
![image](https://user-images.githubusercontent.com/89094811/184910239-51eca19d-e4ee-4177-9598-13184b0f220f.png)
this causing cx to believe the exception comes from functions planform and confuse them. Enhance the user exception by specify if it's a exception comes from user function and what type of exception it is. 


worker side
![image](https://user-images.githubusercontent.com/89094811/185222084-e700eea0-86de-4081-b926-323e05ce88fc.png)

host side
![image](https://user-images.githubusercontent.com/89094811/185222231-8ae4de20-db90-487b-ac4b-ab29b308a134.png)

### Pull request checklist

* [X] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information