### PR TITLE
Dependency injection hooks

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/worker/broker/FunctionMethodExecutorImpl.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/FunctionMethodExecutorImpl.java
@@ -53,11 +53,27 @@ public class FunctionMethodExecutorImpl implements JavaMethodExecutor {
             BindingDataStore dataStore = executionContextDataSource.getDataStore();
             Object retValue = this.overloadResolver.resolve(dataStore)
                     .orElseThrow(() -> new NoSuchMethodException("Cannot locate the method signature with the given input"))
-                    .invoke(() -> this.containingClass.newInstance());
+                    .invoke(() -> {
+                        Object target = executionContextDataSource.getFunctionInstance();
+                        if (target == null) {
+                            target = this.containingClass.newInstance();
+                        }
+                        return target;
+                    });
             dataStore.setDataTargetValue(BindingDataStore.RETURN_NAME, retValue);
         } finally {
             Thread.currentThread().setContextClassLoader(ClassLoader.getSystemClassLoader());
         }
+    }
+
+    @Override
+    public Class<?> getContainingClass() {
+        return containingClass;
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return classLoader;
     }
 
     private Class<?> getContainingClass(String className) throws ClassNotFoundException {

--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
@@ -10,6 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import com.microsoft.azure.functions.middleware.FunctionWorkerMiddleware;
 import com.microsoft.azure.functions.rpc.messages.*;
 import com.microsoft.azure.functions.worker.Constants;
+import com.microsoft.azure.functions.worker.WorkerLogManager;
 import com.microsoft.azure.functions.worker.binding.BindingDataStore;
 import com.microsoft.azure.functions.worker.binding.ExecutionContextDataSource;
 import com.microsoft.azure.functions.worker.binding.ExecutionRetryContext;
@@ -80,7 +81,7 @@ public class JavaFunctionBroker {
 		dataStore.addParameterSources(request.getInputDataList());
 		ExecutionTraceContext traceContext = new ExecutionTraceContext(request.getTraceContext().getTraceParent(), request.getTraceContext().getTraceState(), request.getTraceContext().getAttributesMap());
 		ExecutionRetryContext retryContext = new ExecutionRetryContext(request.getRetryContext().getRetryCount(), request.getRetryContext().getMaxRetryCount(), request.getRetryContext().getException());
-		ExecutionContextDataSource executionContextDataSource = new ExecutionContextDataSource(request.getInvocationId(), methodEntry.left, traceContext, retryContext);
+		ExecutionContextDataSource executionContextDataSource = new ExecutionContextDataSource(executor, request.getInvocationId(), methodEntry.left, traceContext, retryContext);
 		dataStore.addExecutionContextSource(executionContextDataSource);
 		executionContextDataSource.setDataStore(dataStore);
 		this.invocationChainBuilder.build(executor).doNext(executionContextDataSource);

--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodExecutor.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaMethodExecutor.java
@@ -15,4 +15,8 @@ public interface JavaMethodExecutor {
     ParameterResolver getOverloadResolver();
 
     void execute(ExecutionContextDataSource executionContextDataSource) throws Exception;
+
+    Class<?> getContainingClass();
+
+    ClassLoader getClassLoader();
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/chain/FunctionExecutionMiddleware.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/chain/FunctionExecutionMiddleware.java
@@ -3,6 +3,7 @@ package com.microsoft.azure.functions.worker.chain;
 import com.microsoft.azure.functions.ExecutionContext;
 import com.microsoft.azure.functions.middleware.FunctionWorkerChain;
 import com.microsoft.azure.functions.middleware.FunctionWorkerMiddleware;
+import com.microsoft.azure.functions.middleware.MiddlewareExecutionContext;
 import com.microsoft.azure.functions.worker.binding.ExecutionContextDataSource;
 import com.microsoft.azure.functions.worker.broker.JavaMethodExecutor;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -16,7 +17,7 @@ public class FunctionExecutionMiddleware implements FunctionWorkerMiddleware {
     }
 
     @Override
-    public void invoke(ExecutionContext context, FunctionWorkerChain next) throws Exception{
+    public void invoke(MiddlewareExecutionContext context, FunctionWorkerChain next) throws Exception{
             this.functionExecutor.execute((ExecutionContextDataSource) context);
     }
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/chain/InvocationChain.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/chain/InvocationChain.java
@@ -1,8 +1,8 @@
 package com.microsoft.azure.functions.worker.chain;
 
-import com.microsoft.azure.functions.ExecutionContext;
 import com.microsoft.azure.functions.middleware.FunctionWorkerChain;
 import com.microsoft.azure.functions.middleware.FunctionWorkerMiddleware;
+import com.microsoft.azure.functions.middleware.MiddlewareExecutionContext;
 import com.microsoft.azure.functions.worker.broker.JavaMethodExecutor;
 
 import java.util.ArrayList;
@@ -18,7 +18,7 @@ public class InvocationChain implements FunctionWorkerChain {
     }
 
     @Override
-    public void doNext(ExecutionContext context) throws Exception{
+    public void doNext(MiddlewareExecutionContext context) throws Exception{
         while (middlewareIterator.hasNext()) {
             middlewareIterator.next().invoke(context, this);
         }


### PR DESCRIPTION
Allow a FunctionWorkerMiddleware to override target function instance so that middleware can provide a hook for dependency injection framework integrations like Spring and Quarkus and CDI.