### PR TITLE
V3 - Enable placeholders to start with app insights agent using profiles

### DIFF
--- a/package-pipeline.ps1
+++ b/package-pipeline.ps1
@@ -9,6 +9,11 @@ function StopOnFailedExecution {
     exit $LastExitCode 
   }
 }
+
+$ApplicationInsightsAgentVersion = '3.4.0'
+$ApplicationInsightsAgentFilename = "applicationinsights-agent-${ApplicationInsightsAgentVersion}.jar"
+$ApplicationInsightsAgentUrl = "https://repo1.maven.org/maven2/com/microsoft/azure/applicationinsights-agent/${ApplicationInsightsAgentVersion}/${ApplicationInsightsAgentFilename}"
+
 Write-Host "Building azure-functions-java-worker" 
 mvn clean package --no-transfer-progress -B
 StopOnFailedExecution
@@ -25,6 +30,84 @@ copy-item ./worker.config.json pkg
 copy-item ./tools/AzureFunctionsJavaWorker.nuspec pkg/
 Copy-Item ".\lib_worker_1.6.2" pkg\lib -Recurse
 Copy-Item ".\annotationLib" pkg\annotationLib -Recurse
+
+# Download application insights agent from maven central
+$ApplicationInsightsAgentFile = [System.IO.Path]::Combine($PSScriptRoot, $ApplicationInsightsAgentFilename)
+
+# local testing cleanup
+if (Test-Path -Path $ApplicationInsightsAgentFile) {
+    Remove-Item -Path $ApplicationInsightsAgentFile
+}
+
+# local testing cleanup
+$oldOutput = [System.IO.Path]::Combine($PSScriptRoot, "agent")
+if (Test-Path -Path $oldOutput) {
+    Remove-Item -Path $oldOutput -Recurse
+}
+
+# local testing cleanup
+$oldExtract = [System.IO.Path]::Combine($PSScriptRoot, "extract")
+if (Test-Path -Path $oldExtract) {
+    Remove-Item -Path $oldExtract -Recurse
+}
+
+$extract = new-item -type directory -force $PSScriptRoot\extract
+if (-not(Test-Path -Path $extract)) {
+    echo "Fail to create a new directory $extract"
+    exit 1
+}
+
+echo "Start downloading '$ApplicationInsightsAgentUrl' to '$PSScriptRoot'"
+try {
+    Invoke-WebRequest -Uri $ApplicationInsightsAgentUrl -OutFile $ApplicationInsightsAgentFile
+} catch {
+    echo "An error occurred. Download fails" $ApplicationInsightsAgentFile
+    echo "Exiting"
+    exit 1
+}
+
+if (-not(Test-Path -Path $ApplicationInsightsAgentFile)) {
+    echo "$ApplicationInsightsAgentFile do not exist."
+    exit 1
+}
+
+echo "Start extracting content from $ApplicationInsightsAgentFilename to extract folder"
+cd -Path $extract -PassThru
+jar xf $ApplicationInsightsAgentFile
+cd $PSScriptRoot
+echo "Done extracting"
+
+echo "Unsign $ApplicationInsightsAgentFilename"
+Remove-Item $extract\META-INF\MSFTSIG.*
+$manifest = "$extract\META-INF\MANIFEST.MF"
+$newContent = (Get-Content -Raw $manifest | Select-String -Pattern '(?sm)^(.*?\r?\n)\r?\n').Matches[0].Groups[1].Value
+Set-Content -Path $manifest $newContent
+
+Remove-Item $ApplicationInsightsAgentFile
+if (-not(Test-Path -Path $ApplicationInsightsAgentFile)) {
+    echo "Delete the original $ApplicationInsightsAgentFilename successfully"
+} else {
+    echo "Fail to delete original source $ApplicationInsightsAgentFilename"
+    exit 1
+}
+
+$agent = new-item -type directory -force $PSScriptRoot\agent
+$filename = "applicationinsights-agent.jar"
+$result = [System.IO.Path]::Combine($agent, $filename)
+echo "re-jar $filename"
+
+cd -Path $extract -PassThru
+jar cfm $result META-INF/MANIFEST.MF .
+
+if (-not(Test-Path -Path $result)) {
+    echo "Fail to re-archive $filename"
+    exit 1
+}
+Write-Host "Creating the functions.codeless file"
+New-Item -path $PSScriptRoot\agent -type file -name "functions.codeless"
+
+cd $PSScriptRoot
+Copy-Item $PSScriptRoot/agent $PSScriptRoot/pkg/agent -Recurse -Verbose
 set-location pkg
 nuget pack -Properties version=$buildNumber
 set-location ..

--- a/setup-tests-pipeline.ps1
+++ b/setup-tests-pipeline.ps1
@@ -29,6 +29,10 @@ else
 
 $FUNC_CLI_DIRECTORY = Join-Path $PSScriptRoot 'Azure.Functions.Cli'
 
+$ApplicationInsightsAgentVersion = '3.4.0'
+$ApplicationInsightsAgentFilename = "applicationinsights-agent-${ApplicationInsightsAgentVersion}.jar"
+$ApplicationInsightsAgentUrl = "https://repo1.maven.org/maven2/com/microsoft/azure/applicationinsights-agent/${ApplicationInsightsAgentVersion}/${ApplicationInsightsAgentFilename}"
+
 Write-Host 'Deleting the Core Tools if exists...'
 Remove-Item -Force "$FUNC_CLI_DIRECTORY.zip" -ErrorAction Ignore
 Remove-Item -Recurse -Force $FUNC_CLI_DIRECTORY -ErrorAction Ignore
@@ -56,4 +60,83 @@ if (-not $UseCoreToolsBuildFromIntegrationTests.IsPresent)
     Copy-Item "$PSScriptRoot/lib_worker_1.6.2" "$FUNC_CLI_DIRECTORY/workers/java/lib" -Recurse -Verbose
     Write-Host "Copying annotationLib to worker directory"
     Copy-Item "$PSScriptRoot/annotationLib" "$FUNC_CLI_DIRECTORY/workers/java/annotationLib" -Recurse -Verbose
+
+    # Download application insights agent from maven central
+    $ApplicationInsightsAgentFile = [System.IO.Path]::Combine($PSScriptRoot, $ApplicationInsightsAgentFilename)
+
+    # local testing cleanup
+    if (Test-Path -Path $ApplicationInsightsAgentFile) {
+        Remove-Item -Path $ApplicationInsightsAgentFile
+    }
+
+    # local testing cleanup
+    $oldOutput = [System.IO.Path]::Combine($PSScriptRoot, "agent")
+    if (Test-Path -Path $oldOutput) {
+        Remove-Item -Path $oldOutput -Recurse
+    }
+
+    # local testing cleanup
+    $oldExtract = [System.IO.Path]::Combine($PSScriptRoot, "extract")
+    if (Test-Path -Path $oldExtract) {
+        Remove-Item -Path $oldExtract -Recurse
+    }
+
+    echo "Start downloading '$ApplicationInsightsAgentUrl' to '$PSScriptRoot'"
+    try {
+        Invoke-WebRequest -Uri $ApplicationInsightsAgentUrl -OutFile $ApplicationInsightsAgentFile
+    } catch {
+        echo "An error occurred. Download fails" $ApplicationInsightsAgentFile
+        echo "Exiting"
+        exit 1
+    }
+
+    if (-not(Test-Path -Path $ApplicationInsightsAgentFile)) {
+        echo "$ApplicationInsightsAgentFile do not exist."
+        exit 1
+    }
+
+    $extract = new-item -type directory -force $PSScriptRoot\extract
+    if (-not(Test-Path -Path $extract)) {
+        echo "Fail to create a new directory $extract"
+        exit 1
+    }
+
+    echo "Start extracting content from $ApplicationInsightsAgentFilename to extract folder"
+    cd -Path $extract -PassThru
+    jar xf $ApplicationInsightsAgentFile
+    cd $PSScriptRoot
+    echo "Done extracting"
+
+    echo "Unsign $ApplicationInsightsAgentFilename"
+    Remove-Item $extract\META-INF\MSFTSIG.*
+    $manifest = "$extract\META-INF\MANIFEST.MF"
+    $newContent = (Get-Content -Raw $manifest | Select-String -Pattern '(?sm)^(.*?\r?\n)\r?\n').Matches[0].Groups[1].Value
+    Set-Content -Path $manifest $newContent
+
+    Remove-Item $ApplicationInsightsAgentFile
+    if (-not(Test-Path -Path $ApplicationInsightsAgentFile)) {
+        echo "Delete the original $ApplicationInsightsAgentFilename successfully"
+    } else {
+        echo "Fail to delete original source $ApplicationInsightsAgentFilename"
+        exit 1
+    }
+
+    $agent = new-item -type directory -force $PSScriptRoot\agent
+    $filename = "applicationinsights-agent.jar"
+    $result = [System.IO.Path]::Combine($agent, $filename)
+    echo "re-jar $filename"
+
+    cd -Path $extract -PassThru
+    jar cfm $result META-INF/MANIFEST.MF .
+
+    if (-not(Test-Path -Path $result)) {
+        echo "Fail to re-archive $filename"
+        exit 1
+    }
+
+    Write-Host "Creating the functions.codeless file"
+    New-Item -path $PSScriptRoot\agent -type file -name "functions.codeless"
+
+    Write-Host "Copying the unsigned Application Insights Agent to worker directory"
+    Copy-Item "$PSScriptRoot/agent" "$FUNC_CLI_DIRECTORY/workers/java/agent" -Recurse -Verbose
 }

--- a/worker.config.json
+++ b/worker.config.json
@@ -5,5 +5,46 @@
         "defaultExecutablePath": "%JAVA_HOME%/bin/java",
         "defaultWorkerPath": "azure-functions-java-worker.jar",
         "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
-    }
+    },
+    "profiles":
+    [
+        {
+            "profileName":"AppInsightsOptOutWindows",
+            "conditions":[
+                {"conditionType":"environment","conditionName":"languageWorkers:java:arguments","conditionExpression":".*-DaiAgentOptOut.*"},
+                {"conditionType":"hostProperty","conditionName":"platform","conditionExpression":"WINDOWS"}
+            ],
+            "description":{
+                "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
+            }
+        },
+        {
+            "profileName":"AppInsightsOptOutLinux",
+            "conditions":[
+                {"conditionType":"environment","conditionName":"languageWorkers__java__arguments","conditionExpression":".*-DaiAgentOptOut.*"},
+                {"conditionType":"hostProperty","conditionName":"platform","conditionExpression":"LINUX"}
+            ],
+            "description":{
+                "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
+            }
+        },
+        {
+            "profileName":"AppInsightsPlaceholder",
+            "conditions":[
+                {"conditionType":"environment","conditionName":"INITIALIZED_FROM_PLACEHOLDER","conditionExpression":"(?i)true$"}
+            ],
+            "description":{
+                "arguments":["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -javaagent:\"{workerDirectoryPath}/agent/applicationinsights-agent.jar\" -DLazySetOptIn=false -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
+            }
+        },
+        {
+            "profileName":"AppInsightsNoPlaceholder",
+            "conditions":[
+                {"conditionType":"environment","conditionName":"APPLICATIONINSIGHTS_ENABLE_AGENT","conditionExpression":"(?i)true$"}
+            ],
+            "description":{
+                "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -javaagent:\"{workerDirectoryPath}/agent/applicationinsights-agent.jar\" -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
+            }
+        }
+    ]
 }


### PR DESCRIPTION
- Update worker.config.json to include profiles that enable and disable app insights
- Downloads the application insights agent as part of java worker. This includes changes to bring the agent in the java worker release package
- AI agent version 3.4.0 used
- APPLICATIONINSIGHTS_ENABLE_AGENT app setting to enable and disable across all SKUs

resolves #585 

