### PR TITLE
Please remove "jna-platform" dependency from project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,11 +114,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>net.java.dev.jna</groupId>
-      <artifactId>jna-platform</artifactId>
-      <version>5.3.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>4.6.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna-platform</artifactId>
+      <version>5.3.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>4.6.1</version>


### PR DESCRIPTION
Please remove the following dependency from the project.  Because it was not used in the project.

```xml
    <dependency>
      <groupId>net.java.dev.jna</groupId>
      <artifactId>jna-platform</artifactId>
      <version>5.12.1</version>
    </dependency>
```

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Removed unused dependency from project file.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

After I fork the project, I noticed that the above dependency was not used in the project.
So if you removed the library, you could reduce the size of artifacts as follows.

```bash
> ls -l
-rw-r--r--  1 teradayoshio  staff  22983908  9 27 22:40 azure-functions-java-worker-2.6.1-SNAPSHOT.jar
```

```bash
> ls -l
-rw-r--r--  1 teradayoshio  staff  19591598  9 27 22:41 azure-functions-java-worker-2.6.1-SNAPSHOT.jar
```

