### PR TITLE
fix NPE issue

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
@@ -35,7 +35,7 @@ public class JavaFunctionBroker {
 	private final Map<String, ImmutablePair<String, FunctionDefinition>> methods;
 	private final ClassLoaderProvider classLoaderProvider;
 	private String workerDirectory;
-	private boolean oneTimeLogicInitialized = false;
+	private volatile boolean oneTimeLogicInitialized = false;
 	private volatile InvocationChainFactory invocationChainFactory;
 	private volatile FunctionInstanceInjector functionInstanceInjector;
 	private final Object lock = new Object();
@@ -64,11 +64,13 @@ public class JavaFunctionBroker {
 	}
 
 	private void initializeOneTimeLogics() {
-		synchronized (lock) {
-			if (!oneTimeLogicInitialized) {
-				initializeInvocationChainFactory();
-				initializeFunctionInstanceInjector();
-				oneTimeLogicInitialized = true;
+		if (!oneTimeLogicInitialized) {
+			synchronized (lock) {
+				if (!oneTimeLogicInitialized) {
+					initializeInvocationChainFactory();
+					initializeFunctionInstanceInjector();
+					oneTimeLogicInitialized = true;
+				}
 			}
 		}
 	}

--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
@@ -6,8 +6,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
 
 import com.microsoft.azure.functions.internal.spi.middleware.Middleware;
 import com.microsoft.azure.functions.rpc.messages.*;
@@ -38,7 +36,7 @@ public class JavaFunctionBroker {
 	private volatile boolean oneTimeLogicInitialized = false;
 	private volatile InvocationChainFactory invocationChainFactory;
 	private volatile FunctionInstanceInjector functionInstanceInjector;
-	private final Object lock = new Object();
+	private final Object oneTimeLogicInitializationLock = new Object();
 
 	private FunctionInstanceInjector newInstanceInjector() {
 		return new FunctionInstanceInjector() {
@@ -65,7 +63,7 @@ public class JavaFunctionBroker {
 
 	private void initializeOneTimeLogics() {
 		if (!oneTimeLogicInitialized) {
-			synchronized (lock) {
+			synchronized (oneTimeLogicInitializationLock) {
 				if (!oneTimeLogicInitialized) {
 					initializeInvocationChainFactory();
 					initializeFunctionInstanceInjector();

--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
@@ -35,9 +35,10 @@ public class JavaFunctionBroker {
 	private final Map<String, ImmutablePair<String, FunctionDefinition>> methods;
 	private final ClassLoaderProvider classLoaderProvider;
 	private String workerDirectory;
-	private final AtomicBoolean oneTimeLogicInitialized = new AtomicBoolean(false);
+	private boolean oneTimeLogicInitialized = false;
 	private volatile InvocationChainFactory invocationChainFactory;
 	private volatile FunctionInstanceInjector functionInstanceInjector;
+	private final Object lock = new Object();
 
 	private FunctionInstanceInjector newInstanceInjector() {
 		return new FunctionInstanceInjector() {
@@ -63,9 +64,12 @@ public class JavaFunctionBroker {
 	}
 
 	private void initializeOneTimeLogics() {
-		if (!oneTimeLogicInitialized.getAndSet(true)) {
-			initializeInvocationChainFactory();
-			initializeFunctionInstanceInjector();
+		synchronized (lock) {
+			if (!oneTimeLogicInitialized) {
+				initializeInvocationChainFactory();
+				initializeFunctionInstanceInjector();
+				oneTimeLogicInitialized = true;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves [#issue_for_this_pr](https://portal.microsofticm.com/imp/v3/incidents/details/353531000/home)

### Pull request checklist

* [X] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

The root cause is that in java worker we are initialize some singleton in the first function load request, this customer has multiple functions in one function app, when there are multiple function load requests, for ex A & warmup trigger coming almost at same time, let's say A is the first request java worker take to process, before java worker start initialize the singleton object in function A load request (as it's the first load request that we set the atomic flag in it ), it switch to processing warmup trigger load request in a different thread and finished it and return to host, then host send function warmup trigger invocation while function load request A is still be processing by another thread in java worker and the single objects haven't been fully initialized yet. So the invocation of warmup trigger gives the null pointer exception.  
Warmup trigger function is load and invoked
![MicrosoftTeams-image](https://user-images.githubusercontent.com/89094811/206031207-2799d757-2b7a-42b0-943f-8178d35057e0.png)

before singleton object was initialized in first function load request 
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/89094811/206031229-bd1f04fd-b10d-461c-a131-137baec32fa6.png)



Why this issue is not happening before we adding the middleware feature. 

The reason is that before the middleware feature, we don't really care about which function load request finish first. Once there is one function load request finish, then we can start invocation request without any issue. 
But once we add middleware feature, we need the first function load request (because the first function load request will initialize the singleton to be used in invocation request in that onetime logic block) to finish before sending invocations. The first function load request is doing extra work by executing onetime logics to initialize singleton, if the onetime logics block is not synchronized, there is an chance that the first function load request won't be the first one to finish. 





