### PR TITLE
Enable use of nullable maps for headers, params and query

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/worker/Constants.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/Constants.java
@@ -9,4 +9,5 @@ public final class Constants {
     public final static String JAVA_LIBRARY_DIRECTORY = "/annotationLib";
     public final static String JAVA_LIBRARY_ARTIFACT_ID = "azure-functions-java-library";
     public final static String HAS_IMPLICIT_OUTPUT_QUALIFIED_NAME = "com.microsoft.azure.functions.annotation.HasImplicitOutput";
+    public final static String NULLABLE_VALUES_ENABLED_APP_SETTING = "FUNCTIONS_WORKER_NULLABLE_VALUES_ENABLED";
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/binding/RpcHttpRequestDataSource.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/binding/RpcHttpRequestDataSource.java
@@ -6,7 +6,9 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import com.microsoft.azure.functions.rpc.messages.NullableTypes;
 import org.apache.commons.lang3.reflect.TypeUtils;
 
 import com.microsoft.azure.functions.HttpMethod;
@@ -22,8 +24,10 @@ public final class RpcHttpRequestDataSource extends DataSource<RpcHttpRequestDat
 		super(name, null, HTTP_DATA_OPERATIONS);
 		this.httpPayload = value;
 		this.bodyDataSource = BindingDataStore.rpcSourceFromTypedData(null, this.httpPayload.getBody());
-		this.fields = Arrays.asList(this.httpPayload.getHeadersMap(), this.httpPayload.getQueryMap(),
-				this.httpPayload.getParamsMap());
+		this.fields = Arrays.asList(
+				convertFromNullableMap(this.httpPayload.getNullableHeadersMap()),
+				convertFromNullableMap(this.httpPayload.getNullableQueryMap()),
+				convertFromNullableMap(this.httpPayload.getNullableParamsMap()));
 		this.setValue(this);
 	}
 
@@ -45,12 +49,12 @@ public final class RpcHttpRequestDataSource extends DataSource<RpcHttpRequestDat
 
 		@Override
 		public Map<String, String> getHeaders() {
-			return this.parentDataSource.httpPayload.getHeadersMap();
+			return convertFromNullableMap(this.parentDataSource.httpPayload.getNullableHeadersMap());
 		}
 
 		@Override
 		public Map<String, String> getQueryParameters() {
-			return this.parentDataSource.httpPayload.getQueryMap();
+			return convertFromNullableMap(this.parentDataSource.httpPayload.getNullableQueryMap());
 		}
 
 		@Override
@@ -85,5 +89,11 @@ public final class RpcHttpRequestDataSource extends DataSource<RpcHttpRequestDat
 			BindingData bodyData = v.bodyDataSource.computeByType(actualType).orElseThrow(ClassCastException::new);
 			return new HttpRequestMessageImpl(v, bodyData.getValue());
 		});
+	}
+
+	private static Map<String, String> convertFromNullableMap(Map<String, NullableTypes.NullableString> nullableMap) {
+		return nullableMap.entrySet().stream().collect(
+			Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getValue())
+		);
 	}
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/binding/RpcHttpRequestDataSource.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/binding/RpcHttpRequestDataSource.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.microsoft.azure.functions.rpc.messages.NullableTypes;
+import com.microsoft.azure.functions.worker.Constants;
 import com.microsoft.azure.functions.worker.Util;
 import org.apache.commons.lang3.reflect.TypeUtils;
 
@@ -93,7 +94,7 @@ public final class RpcHttpRequestDataSource extends DataSource<RpcHttpRequestDat
 	}
 
 	private static Map<String, String> convertFromNullableMap(Map<String, NullableTypes.NullableString> nullableMap) {
-		if (Util.isTrue(System.getenv("FUNCTIONS_WORKER_NULLABLE_VALUES_ENABLED"))) {
+		if (Util.isTrue(System.getenv(Constants.NULLABLE_VALUES_ENABLED_APP_SETTING))) {
 			return nullableMap.entrySet().stream().collect(
 					Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getValue())
 			);

--- a/src/main/java/com/microsoft/azure/functions/worker/handler/WorkerInitRequestHandler.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/handler/WorkerInitRequestHandler.java
@@ -23,6 +23,7 @@ public class WorkerInitRequestHandler extends MessageHandler<WorkerInitRequest, 
         response.putCapabilities("TypedDataCollection", "TypedDataCollection");
         response.putCapabilities("WorkerStatus", "WorkerStatus");
         response.putCapabilities("RpcHttpBodyOnly", "RpcHttpBodyOnly");
+        response.putCapabilities("UseNullableValueDictionaryForHttp", "UseNullableValueDictionaryForHttp");
         response.putCapabilities("RpcHttpTriggerMetadataRemoved", "RpcHttpTriggerMetadataRemoved");
         response.putCapabilities("HandlesWorkerTerminateMessage", "HandlesWorkerTerminateMessage");
         response.setWorkerMetadata(composeWorkerMetadata());

--- a/src/test/java/com/microsoft/azure/functions/worker/binding/tests/RpcHttpRequestDataSourceTest.java
+++ b/src/test/java/com/microsoft/azure/functions/worker/binding/tests/RpcHttpRequestDataSourceTest.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.functions.HttpRequestMessage;
 import com.microsoft.azure.functions.HttpStatus;
 import com.microsoft.azure.functions.rpc.messages.RpcHttp;
 import com.microsoft.azure.functions.rpc.messages.TypedData;
+import com.microsoft.azure.functions.worker.Constants;
 import com.microsoft.azure.functions.worker.binding.*;
 import com.microsoft.azure.functions.worker.broker.JavaFunctionBroker;
 import com.microsoft.azure.functions.worker.handler.FunctionEnvironmentReloadRequestHandler;
@@ -63,7 +64,7 @@ public class RpcHttpRequestDataSourceTest {
     Map<String, String> existingVariables = System.getenv();
     Map<String, String> newEnvVariables = new HashMap<>();
     newEnvVariables.putAll(existingVariables);
-    newEnvVariables.put("FUNCTIONS_WORKER_NULLABLE_VALUES_ENABLED", "true");
+    newEnvVariables.put(Constants.NULLABLE_VALUES_ENABLED_APP_SETTING, "true");
     envHandler.setEnv(newEnvVariables);
     Method httpRequestMessageStringBodyMethod = getFunctionMethod("HttpRequestStringBody");
     Map<String, String> queryMap = new HashMap<String, String>() {{
@@ -97,7 +98,7 @@ public class RpcHttpRequestDataSourceTest {
     Map<String, String> existingVariables = System.getenv();
     Map<String, String> newEnvVariables = new HashMap<>();
     newEnvVariables.putAll(existingVariables);
-    newEnvVariables.put("FUNCTIONS_WORKER_NULLABLE_VALUES_ENABLED", "false");
+    newEnvVariables.put(Constants.NULLABLE_VALUES_ENABLED_APP_SETTING, "false");
     envHandler.setEnv(newEnvVariables);
     Method httpRequestMessageStringBodyMethod = getFunctionMethod("HttpRequestStringBody");
     Map<String, String> queryMap = new HashMap<String, String>() {{


### PR DESCRIPTION
BREAKING CHANGE: Enabled the `UseNullableValueDictionaryForHttp` capability which makes the host send back request information in nullable maps (i.e. When the `UseNullableValueDictionaryForHttp` capability is enabled, the host stores the values in `nullable_headers`, `nullable_params` and `nullable_query` instead of `headers`, `params` and `query`)

### Issue describing the changes in this PR
**Context:**
This is the sample function app code run for the screenshots below:
![image](https://user-images.githubusercontent.com/102087132/213805697-c8d24176-d4d2-4857-85d6-39eb98fc6c6c.png)
**Before:**
Without this capability, if the customer were to set an empty string as the query value, the host would not add the entry to the query map. This means that if the customer were to try to access that entry from the query map (via the `getQueryParameters` function), they would just get `null`.
![beforeChanges](https://user-images.githubusercontent.com/102087132/213805143-b0aa3df2-2cac-4941-b88f-3b26f0b84a12.png)
**After:**
With this capability, if the customer were to set an empty string as the query value, the host would add the entry to the query map with the value just being the empty string.
![withChanges](https://user-images.githubusercontent.com/102087132/213805550-ac5d0390-6b79-4347-9614-aec2ef60f40a.png)

This is meant to resolve issue #683 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
