### PR TITLE
update to catch Throwable for execute method

### DIFF
--- a/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/HttpEndToEndTests.cs
+++ b/endtoendtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/HttpEndToEndTests.cs
@@ -66,5 +66,11 @@ namespace Azure.Functions.Java.Tests.E2E
         {
             Assert.True(await Utilities.InvokeHttpTrigger("BindingName", "/testMessage", HttpStatusCode.OK, "testMessage"));
         }
+
+        [Fact]
+        public async Task HttpTrigger_StaticBlockFailure()
+        {
+            Assert.True(await Utilities.InvokeHttpTrigger("StaticBlockFailure", "", HttpStatusCode.InternalServerError, ""));
+        }
     }
 }

--- a/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/StaticBlockFailure.java
+++ b/endtoendtests/src/main/java/com/microsoft/azure/functions/endtoend/StaticBlockFailure.java
@@ -1,0 +1,25 @@
+package com.microsoft.azure.functions.endtoend;
+
+import com.microsoft.azure.functions.*;
+import com.microsoft.azure.functions.annotation.AuthorizationLevel;
+import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.HttpTrigger;
+
+import java.util.Optional;
+
+public class StaticBlockFailure {
+    static {
+        Optional.empty().orElseThrow(() -> new RuntimeException("exception raised in static block"));
+    }
+    @FunctionName("StaticBlockFailure")
+    public HttpResponseMessage run(
+            @HttpTrigger(
+                    name = "req",
+                    methods = {HttpMethod.GET, HttpMethod.POST},
+                    authLevel = AuthorizationLevel.ANONYMOUS)
+            HttpRequestMessage<Optional<String>> request,
+            final ExecutionContext context) {
+        context.getLogger().info("Java HTTP trigger processed a request of function StaticBlockFailure.");
+        return request.createResponseBuilder(HttpStatus.OK).body("Hello, e2e test").build();
+    }
+}

--- a/src/main/java/com/microsoft/azure/functions/worker/handler/MessageHandler.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/handler/MessageHandler.java
@@ -45,10 +45,10 @@ public abstract class MessageHandler<TRequest extends Message, TResponse extends
             if (statusMessage != null) {
                 this.getLogger().info(statusMessage);
             }
-        } catch (Exception ex) {
+        } catch (Throwable throwable) {
             status = StatusResult.Status.Failure;
-            statusMessage = ExceptionUtils.getRootCauseMessage(ex);
-            rpcException = RpcException.newBuilder().setMessage(statusMessage).setStackTrace(ExceptionUtils.getStackTrace(ex)).build();
+            statusMessage = ExceptionUtils.getRootCauseMessage(throwable);
+            rpcException = RpcException.newBuilder().setMessage(statusMessage).setStackTrace(ExceptionUtils.getStackTrace(throwable)).build();
         }
         if (this.responseStatusMarshaller != null) {
             StatusResult.Builder result = StatusResult.newBuilder().setStatus(status).setResult(statusMessage);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #295 

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

- [ ] Need to test out on production, especially for durable functions. 

Catching `Exception` will igore `Error` happend in java worker process or customer code. This resulted in host hanging up for 30mins and time out, since host never get chance to know that an `Error` happened in java worker. This is because `Error` won't be caught and it will break the current logics to response the host request through grpc. 
<img width="1894" alt="image" src="https://user-images.githubusercontent.com/89094811/218861302-822b4912-e371-4ae8-9c43-5e264c8ef5e0.png">


Update to catch `Throwable` so that any `Error` type will also be caught and inform host through grpc. 
Didn't re-throw the `Throwable` as there is not much difference, as long as we get this `Error` info passed back to host. 