### PR TITLE
potential support for customize gson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <azure.functions.java.core.library.version>1.2.0</azure.functions.java.core.library.version>
-    <azure.functions.java.spi>1.0.0</azure.functions.java.spi>
+    <azure.functions.java.spi>1.1.0</azure.functions.java.spi>
     <azure.functions.java.library.version>2.2.0</azure.functions.java.library.version>
     <jupiter.version>5.9.1</jupiter.version>
     <mockito-core.version>4.11.0</mockito-core.version>

--- a/src/main/java/com/microsoft/azure/functions/worker/Util.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/Util.java
@@ -1,6 +1,11 @@
 package com.microsoft.azure.functions.worker;
 
+import com.google.gson.Gson;
+import com.microsoft.azure.functions.spi.inject.GsonInstanceInjector;
+
 public class Util {
+    private static Gson gsonInstance;
+    private static final Object utilLock = new Object();
     public static boolean isTrue(String value) {
         if(value != null && (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("1"))) {
             return true;
@@ -11,4 +16,19 @@ public class Util {
     public static String getJavaVersion() {
         return String.join(" - ", System.getProperty("java.home"), System.getProperty("java.version"));
     }
+
+    public static void setGsonInstance(Gson instance) {
+        if (gsonInstance == null) {
+            synchronized (utilLock) {
+                if (gsonInstance == null) {
+                    gsonInstance = instance;
+                }
+            }
+        }
+    }
+
+    public static Gson getGsonInstance() {
+        return gsonInstance;
+    }
+
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/Util.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/Util.java
@@ -18,13 +18,7 @@ public class Util {
     }
 
     public static void setGsonInstance(Gson instance) {
-        if (gsonInstance == null) {
-            synchronized (utilLock) {
-                if (gsonInstance == null) {
-                    gsonInstance = instance;
-                }
-            }
-        }
+        gsonInstance = instance;
     }
 
     public static Gson getGsonInstance() {

--- a/src/main/java/com/microsoft/azure/functions/worker/binding/RpcJsonDataSource.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/binding/RpcJsonDataSource.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import com.microsoft.azure.functions.worker.Util;
 import org.apache.commons.lang3.reflect.TypeUtils;
 
 import com.google.gson.Gson;
@@ -17,7 +18,7 @@ public final class RpcJsonDataSource extends DataSource<String> {
 		super(name, value, JSON_DATA_OPERATIONS);
 	}
 
-	public static final Gson gson = new Gson();
+	public static final Gson gson = Util.getGsonInstance();
 	public static final JsonParser gsonParser = new JsonParser();
 	private static final DataOperations<String, Object> JSON_DATA_OPERATIONS = new DataOperations<>();
 

--- a/src/test/java/com/microsoft/azure/functions/worker/binding/tests/RpcByteArrayDataSourceTest.java
+++ b/src/test/java/com/microsoft/azure/functions/worker/binding/tests/RpcByteArrayDataSourceTest.java
@@ -4,15 +4,23 @@ package com.microsoft.azure.functions.worker.binding.tests;
 import java.lang.invoke.WrongMethodTypeException;
 import java.util.Optional;
 
+import com.google.gson.Gson;
+import com.microsoft.azure.functions.worker.Util;
 import org.apache.commons.lang3.ArrayUtils;
 
 import com.google.protobuf.ByteString;
 import com.microsoft.azure.functions.worker.binding.BindingData;
 import com.microsoft.azure.functions.worker.binding.RpcByteArrayDataSource;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RpcByteArrayDataSourceTest {
+
+  @BeforeAll
+  public static void setGsonInstance() {
+    Util.setGsonInstance(new Gson());
+  }
 
   @Test
   public void rpcByteArrayDataSource_To_byteArray() {

--- a/src/test/java/com/microsoft/azure/functions/worker/binding/tests/RpcStringDataSourceTest.java
+++ b/src/test/java/com/microsoft/azure/functions/worker/binding/tests/RpcStringDataSourceTest.java
@@ -8,11 +8,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import com.microsoft.azure.functions.worker.Util;
 import com.microsoft.azure.functions.worker.binding.BindingData;
 import com.microsoft.azure.functions.worker.binding.RpcJsonDataSource;
 import com.microsoft.azure.functions.worker.binding.RpcStringDataSource;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -30,6 +33,11 @@ public class RpcStringDataSourceTest {
     }
 
     public void FunctionWithStringListInput(List<String> items) {
+    }
+
+    @BeforeAll
+    public static void setGsonInstance() {
+        Util.setGsonInstance(new Gson());
     }
 
     @Test


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

A primitive implementation for support customizing gson instance used in java worker. 
Issues opened on hard code gson instance are many: https://github.com/Azure/azure-functions-java-worker/issues/682, https://github.com/Azure/azure-functions-java-worker/issues/424, https://github.com/Azure/azure-functions-java-worker/issues/419, https://github.com/Azure/azure-functions-host/issues/7391, etc.

So maybe it's good to add flexibility supporting customer customize their gson instance. 
Another solution would be work with Azure java sdk team on moving out of gson with better choice. 
Board link: https://msazure.visualstudio.com/Antares/_boards/board/t/Functions%20Java/Backlog%20items/?workitem=17209424

SPI requirement: https://github.com/Azure/azure-functions-java-additions/pull/20

**This feature may not be needed at all, as most customer can using plan String and customize their gson instance inside their function to deserialize.** 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information