### PR TITLE
feat: enabling java function dev experience in vscode + devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,56 @@
+# Reference: https://github.com/devcontainers/images/blob/main/src/java/.devcontainer/Dockerfile
+ARG TARGET_JAVA_VERSION=21
+ARG BASE_IMAGE_VERSION_CODENAME=bookworm
+FROM mcr.microsoft.com/devcontainers/base:${BASE_IMAGE_VERSION_CODENAME}
+
+USER root
+ARG TARGET_JAVA_VERSION
+ENV JAVA_HOME /usr/lib/jvm/msopenjdk-current
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+# Default to UTF-8 file.encoding
+ENV LANG en_US.UTF-8
+
+# Install Microsoft OpenJDK
+RUN arch="$(dpkg --print-architecture)" \
+	&& case "$arch" in \
+		"amd64") \
+			jdkUrl="https://aka.ms/download-jdk/microsoft-jdk-${TARGET_JAVA_VERSION}-linux-x64.tar.gz"; \
+			;; \
+		"arm64") \
+			jdkUrl="https://aka.ms/download-jdk/microsoft-jdk-${TARGET_JAVA_VERSION}-linux-aarch64.tar.gz"; \
+			;; \
+		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
+	esac \
+	\
+	&& wget --progress=dot:giga -O msopenjdk.tar.gz "${jdkUrl}" \
+	&& wget --progress=dot:giga -O sha256sum.txt "${jdkUrl}.sha256sum.txt" \
+	\
+	&& sha256sumText=$(cat sha256sum.txt) \
+	&& sha256=$(expr substr "${sha256sumText}" 1 64) \
+	&& echo "${sha256} msopenjdk.tar.gz" | sha256sum --strict --check - \
+	&& rm sha256sum.txt* \
+	\
+	&& mkdir -p "$JAVA_HOME" \
+	&& tar --extract \
+		--file msopenjdk.tar.gz \
+		--directory "$JAVA_HOME" \
+		--strip-components 1 \
+		--no-same-owner \
+	&& rm msopenjdk.tar.gz* \
+	\
+	&& ln -s ${JAVA_HOME} /docker-java-home \
+	&& ln -s ${JAVA_HOME} /usr/local/openjdk-${TARGET_JAVA_VERSION}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+
+# Install Maven
+RUN apt-get update && apt-get install -y maven
+
+# Install coretools package from linux software repository
+RUN curl -sSL -O https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update && apt-get install azure-functions-core-tools-4

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+    "name": "Azure Java Function Worker Development",
+    "build": {
+        "dockerfile": "./Dockerfile",
+        "context": "."
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/java:1": {
+            "version": "none"
+        },
+        "ghcr.io/devcontainers/features/node:1": "none",
+        "ghcr.io/devcontainers/features/git:1": {
+            "version": "latest",
+            "ppa": "false"
+        }
+    },
+    "containerEnv": {
+        "JAVA_HOME": "/usr/lib/jvm/msopenjdk-current"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "vscjava.vscode-java-pack",        // Java extension pack for VS Code
+                "vscjava.vscode-java-debug",        // Java debug extension
+                "vscjava.vscode-maven",            // Maven extension for VS Code
+                "ms-azuretools.vscode-azurefunctions",  // Azure Functions extension
+                "ms-azuretools.vscode-azurestorage",  // Azure Storage,
+                "Azurite.azurite"  // Azurite extension
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Proposing adding devcontainer files to enable azure java function developers to easily contribute to open source or write java functions by using vscode devcontainer extension in their local boxes.

Step1. Open azure java function worker repo in VsCode
Step2. Install DevContainers extension
![{9A296104-EE18-4596-A9D2-CB1B3F3DCA19}](https://github.com/user-attachments/assets/4d454409-8fbf-4995-9b42-0a3ca7a558f7)
Step3. ctrl+shift+p to open command pallete and invoke dev containers command to rebuild and reopen devcontainer
![{FB6FD8B5-3840-45FF-BEBD-CFAF964D347C}](https://github.com/user-attachments/assets/cd53cfdb-e8f5-4419-86f5-f3e89c801839)
this will build and run a dev container using the config files in root repo of currently opened repo. by default the container mounts the currently opened local dir from host machine which means users can make changes from local VsCode and changes are reflected inside the devcontainer.

Step4. Wait for devcontainer to be running and once ready, you can work on azure java function out of box, with all the tools/extensions/libs installed for you in devcontainer.
![{D219136F-8511-407D-B453-707E383973E1}](https://github.com/user-attachments/assets/2769d952-b9c1-4ff3-b418-c2ebef794834)


### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information