### PR TITLE
feat: support full jvm arg override

### DIFF
--- a/worker.config.json
+++ b/worker.config.json
@@ -45,6 +45,15 @@
             "description":{
                 "arguments": ["-XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify -Djava.net.preferIPv4Stack=true -javaagent:\"{workerDirectoryPath}/agent/applicationinsights-agent.jar\" -jar", "%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
             }
+        },
+        {
+            "profileName":"CustomDefined",
+            "conditions":[
+                {"conditionType":"environment","conditionName":"OVERRIDE_JVM_ARG","conditionExpression":"(?i)true$"}
+            ],
+            "description":{
+                "arguments": ["%JAVA_OPTS%", "%AZURE_FUNCTIONS_MESH_JAVA_OPTS%"]
+            }
         }
     ]
 }


### PR DESCRIPTION
New app setting OVERRIDE_JVM_ARG, allowing full override of worker jvm arguments
Addressing issue like https://github.com/Azure/azure-functions-java-worker/issues/782
![{4CC2980F-3A21-46C1-8F53-A828DBEF33E3}](https://github.com/user-attachments/assets/a2ce0033-f7be-4adc-b355-bcac1c8f5eea)
![{257BCDBE-4B8D-4847-93C1-17520E5BA43F}](https://github.com/user-attachments/assets/1b37366e-1384-409b-b845-294a7241a3f7)

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information