### PR TITLE
fix: CodeQL - exclude generated temp folder from CodeQL analysis

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -46,6 +46,7 @@ extends:
             codeql:
               language: java,powershell
               runSourceLanguagesInSourceAnalysis: true
+              buildIdentifier: java_worker_official
         jobs:
           - template: /eng/ci/templates/official/jobs/build-artifacts.yml@self
 
@@ -55,6 +56,8 @@ extends:
           sdl:
             codeql:
               language: csharp
+              buildIdentifier: java_worker_csharp_official
+              excludePathPatterns: '/extract/inst'
         jobs:
           - template: /eng/ci/templates/official/jobs/run-e2e-tests-windows.yml@self
 

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -42,6 +42,7 @@ extends:
           sdl:
             codeql:
               language: java,powershell
+              buildIdentifier: java_worker_public
               runSourceLanguagesInSourceAnalysis: true
         jobs:
           - template: /eng/ci/templates/jobs/build.yml@self
@@ -52,6 +53,8 @@ extends:
           sdl:
             codeql:
               language: csharp
+              buildIdentifier: java_worker_csharp_public
+              excludePathPatterns: '/extract/inst'
         jobs:
           - template: /eng/ci/templates/jobs/run-emulated-tests-windows.yml@self
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests) - N/A

<!-- Optional: delete if not applicable  -->
### Additional information
```
Set Codeql.ExcludePathPatterns variable to ‘extract’, i.e. CodeQL. ExcludePathPatterns=extract
This will exclude extract folder from CodeQL analysis. You may also set it to “/extract/inst” to exclude only “inst” folder under “extract”
```
Additional PR information