### PR TITLE
Bumps gson version in order to work with Spingboot 3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.9.0</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

When using SpringBoot 3.4 this inside the azure-functions-docker conteiner apps are not starting due to a mismatch with gson versions. Gson 2.11.0 needs to be included in order for springboot to work properly. It does not help to bundle it with the application since the stuff in this jar file it loaded before the springboot app.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md` - there is no such file that I could find
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests) - tests are not working on the dev branch.

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information