### PR TITLE
update guava version to 33.3.1 for function apps used for testing

### DIFF
--- a/emulatedtests/pom.xml
+++ b/emulatedtests/pom.xml
@@ -83,7 +83,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>32.0.0-jre</version>
+			<version>33.3.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/endtoendtests/pom.xml
+++ b/endtoendtests/pom.xml
@@ -83,7 +83,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>32.0.0-jre</version>
+			<version>33.3.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>


### PR DESCRIPTION
Current version 32.0.0 is still flagged for CVE-2023-2976 even though the vulnerability was patched in that version. The patch introduced some issues on Windows and the recommendation is to use 32.0.1 or higher where those issues are fixed. 

https://nvd.nist.gov/vuln/detail/CVE-2023-2976


<!-- Please provide all the information below.  -->

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information