### PR TITLE
enable codeql on public pipeline

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -31,6 +31,8 @@ variables:
     value: java_worker_public
   - name: codeql.excludePathPatterns
     value: extract/inst
+  - name: codeql.compiled.enabled
+    value: true
 
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
codeql.compiled.enabled true

by default it is not enabled for unofficial 1ES PT, we are using unofficial 1ES PT for public and official PT for internal

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests) - N/A

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information