### PR TITLE
update appinsights agent version and move it to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <azure.functions.java.library.version>2.2.0</azure.functions.java.library.version>
     <jupiter.version>5.9.1</jupiter.version>
     <mockito-core.version>4.11.0</mockito-core.version>
+    <appinsights.agents.version>3.6.2</appinsights.agents.version>
   </properties>
   <licenses>
     <license>
@@ -321,4 +322,51 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>appinsights</id>
+      <dependencies>
+        <dependency>
+          <groupId>com.microsoft.azure</groupId>
+          <artifactId>applicationinsights-agent</artifactId>
+          <version>${appinsights.agents.version}</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <plugins>
+          <!--
+            Use the Maven Dependency Plugin to copy the agent from your local Maven repo
+            into target/agent/applicationinsights-agent.jar at package time.
+          -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>3.5.0</version>
+            <executions>
+              <execution>
+                <id>copy-ai-agent</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>com.microsoft.azure</groupId>
+                      <artifactId>applicationinsights-agent</artifactId>
+                      <version>${appinsights.agents.version}</version>
+                      <outputDirectory>${project.build.directory}/agent</outputDirectory>
+                      <destFileName>applicationinsights-agent.jar</destFileName>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/setup-tests-pipeline.ps1
+++ b/setup-tests-pipeline.ps1
@@ -29,10 +29,6 @@ else
 
 $FUNC_CLI_DIRECTORY = Join-Path $PSScriptRoot 'Azure.Functions.Cli'
 
-$ApplicationInsightsAgentVersion = '3.5.4'
-$ApplicationInsightsAgentFilename = "applicationinsights-agent-${ApplicationInsightsAgentVersion}.jar"
-$ApplicationInsightsAgentUrl = "https://repo1.maven.org/maven2/com/microsoft/azure/applicationinsights-agent/${ApplicationInsightsAgentVersion}/${ApplicationInsightsAgentFilename}"
-
 Write-Host 'Deleting the Core Tools if exists...'
 Remove-Item -Force "$FUNC_CLI_DIRECTORY.zip" -ErrorAction Ignore
 Remove-Item -Recurse -Force $FUNC_CLI_DIRECTORY -ErrorAction Ignore
@@ -58,83 +54,6 @@ if (-not $UseCoreToolsBuildFromIntegrationTests.IsPresent)
     Copy-Item "$PSScriptRoot/worker.config.json" "$FUNC_CLI_DIRECTORY/workers/java" -Force -Verbose
     Write-Host "Copying worker.config.json and annotationLib to worker directory"
     Copy-Item "$PSScriptRoot/annotationLib" "$FUNC_CLI_DIRECTORY/workers/java" -Recurse -Verbose -Force
-
-    # Download application insights agent from maven central
-    $ApplicationInsightsAgentFile = [System.IO.Path]::Combine($PSScriptRoot, $ApplicationInsightsAgentFilename)
-
-    # local testing cleanup
-    if (Test-Path -Path $ApplicationInsightsAgentFile) {
-        Remove-Item -Path $ApplicationInsightsAgentFile
-    }
-
-    # local testing cleanup
-    $oldOutput = [System.IO.Path]::Combine($PSScriptRoot, "agent")
-    if (Test-Path -Path $oldOutput) {
-        Remove-Item -Path $oldOutput -Recurse
-    }
-
-    # local testing cleanup
-    $oldExtract = [System.IO.Path]::Combine($PSScriptRoot, "extract")
-    if (Test-Path -Path $oldExtract) {
-        Remove-Item -Path $oldExtract -Recurse
-    }
-
-    echo "Start downloading '$ApplicationInsightsAgentUrl' to '$PSScriptRoot'"
-    try {
-        Invoke-WebRequest -Uri $ApplicationInsightsAgentUrl -OutFile $ApplicationInsightsAgentFile
-    } catch {
-        echo "An error occurred. Download fails" $ApplicationInsightsAgentFile
-        echo "Exiting"
-        exit 1
-    }
-
-    if (-not(Test-Path -Path $ApplicationInsightsAgentFile)) {
-        echo "$ApplicationInsightsAgentFile do not exist."
-        exit 1
-    }
-
-    $extract = new-item -type directory -force $PSScriptRoot\extract
-    if (-not(Test-Path -Path $extract)) {
-        echo "Fail to create a new directory $extract"
-        exit 1
-    }
-
-    echo "Start extracting content from $ApplicationInsightsAgentFilename to extract folder"
-    cd -Path $extract -PassThru
-    jar xf $ApplicationInsightsAgentFile
-    cd $PSScriptRoot
-    echo "Done extracting"
-
-    echo "Unsign $ApplicationInsightsAgentFilename"
-    Remove-Item $extract\META-INF\MSFTSIG.*
-    $manifest = "$extract\META-INF\MANIFEST.MF"
-    $newContent = (Get-Content -Raw $manifest | Select-String -Pattern '(?sm)^(.*?\r?\n)\r?\n').Matches[0].Groups[1].Value
-    Set-Content -Path $manifest $newContent
-
-    Remove-Item $ApplicationInsightsAgentFile
-    if (-not(Test-Path -Path $ApplicationInsightsAgentFile)) {
-        echo "Delete the original $ApplicationInsightsAgentFilename successfully"
-    } else {
-        echo "Fail to delete original source $ApplicationInsightsAgentFilename"
-        exit 1
-    }
-
-    $agent = new-item -type directory -force $PSScriptRoot\agent
-    $filename = "applicationinsights-agent.jar"
-    $result = [System.IO.Path]::Combine($agent, $filename)
-    echo "re-jar $filename"
-
-    cd -Path $extract -PassThru
-    jar cfm $result META-INF/MANIFEST.MF .
-
-    if (-not(Test-Path -Path $result)) {
-        echo "Fail to re-archive $filename"
-        exit 1
-    }
-
-    Write-Host "Creating the functions.codeless file"
-    New-Item -path $PSScriptRoot\agent -type file -name "functions.codeless"
-
     Write-Host "Copying the unsigned Application Insights Agent to worker directory"
     Copy-Item "$PSScriptRoot/agent" "$FUNC_CLI_DIRECTORY/workers/java" -Recurse -Verbose -Force
 }


### PR DESCRIPTION
- add a new `appinsights` profile to the pom.xml that downloads the appinsights agent 
- update the packaging and integration testing scripts to use the maven downloaded agent instead of manually downloading it


### Pull request checklist

* [ ] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)