### PR TITLE
Remove signatures in-place from AppInsights agent jar before adding it to worker package

### DIFF
--- a/package-pipeline.ps1
+++ b/package-pipeline.ps1
@@ -41,45 +41,79 @@ if (Test-Path -Path $oldOutput) {
     Remove-Item -Path $oldOutput -Recurse
 }
 
-## local testing cleanup
-#$oldExtract = [System.IO.Path]::Combine($PSScriptRoot, "extract")
-#if (Test-Path -Path $oldExtract) {
-#    Remove-Item -Path $oldExtract -Recurse
-#}
-#
-#$extract = new-item -type directory -force $PSScriptRoot\extract
-#if (-not(Test-Path -Path $extract)) {
-#    echo "Fail to create a new directory $extract"
-#    exit 1
-#}
-#
-#echo "Start extracting content from $ApplicationInsightsAgentFile to extract folder"
-#cd -Path $extract -PassThru
-#jar xf $ApplicationInsightsAgentFile
-#cd $PSScriptRoot
-#echo "Done extracting"
-#
-#echo "Unsign $ApplicationInsightsAgentFile"
-#Remove-Item $extract\META-INF\MSFTSIG.*
-#$manifest = "$extract\META-INF\MANIFEST.MF"
-#$newContent = (Get-Content -Raw $manifest | Select-String -Pattern '(?sm)^(.*?\r?\n)\r?\n').Matches[0].Groups[1].Value
-#Set-Content -Path $manifest $newContent
-
 $agent = new-item -type directory -force $PSScriptRoot\agent
 $filename = "applicationinsights-agent.jar"
-#$result = [System.IO.Path]::Combine($agent, $filename)
-#echo "re-jar $filename"
-#
-#cd -Path $extract -PassThru
-#jar cfm $result META-INF/MANIFEST.MF .
-#
-#if (-not(Test-Path -Path $result)) {
-#    echo "Fail to re-archive $filename"
-#    exit 1
-#}
+$packagedAgentFile = Join-Path $agent $filename
 
-Copy-Item $ApplicationInsightsAgentFile -Destination (Join-Path $agent $filename)
-Write-Host "Agent copied successfully to $agentDir"
+Copy-Item $ApplicationInsightsAgentFile -Destination $packagedAgentFile
+Write-Host "Agent copied successfully to $packagedAgentFile"
+
+# Load the required assembly for ZipArchive
+Add-Type -AssemblyName System.IO.Compression, System.IO.Compression.FileSystem
+
+Write-Host "Removing signature files from $packagedAgentFile ..."
+
+# Open the jar as a zip archive in "Update" mode
+$fileStream = [System.IO.File]::Open($packagedAgentFile, [System.IO.FileMode]::Open)
+$zipArchive = New-Object System.IO.Compression.ZipArchive($fileStream, [System.IO.Compression.ZipArchiveMode]::Update)
+
+try {
+    # 1) Remove signature files (META-INF/MSFTSIG.*, .SF, .RSA, .DSA)
+    Write-Host "Removing signature files..."
+    $entriesToRemove = $zipArchive.Entries | Where-Object {
+        $_.FullName -like "META-INF/MSFTSIG.*" `
+        -or $_.FullName -like "META-INF/*.SF" `
+        -or $_.FullName -like "META-INF/*.RSA" `
+        -or $_.FullName -like "META-INF/*.DSA"
+    }
+
+    foreach ($entry in $entriesToRemove) {
+        Write-Host "  Deleting: $($entry.FullName)"
+        $entry.Delete()
+    }
+
+    # 2) Locate the MANIFEST.MF entry
+    $manifestEntry = $zipArchive.Entries | Where-Object { $_.FullName -eq "META-INF/MANIFEST.MF" }
+    if ($manifestEntry) {
+        Write-Host "Removing signature references from MANIFEST.MF ..."
+
+        # Read the existing manifest
+        $reader = New-Object System.IO.StreamReader($manifestEntry.Open())
+        $manifestContent = $reader.ReadToEnd()
+        $reader.Close()
+
+        $pattern = '(?sm)^(.*?\r?\n)\r?\n'
+        $matches = [regex]::Matches($manifestContent, $pattern)
+
+        if ($matches.Count -gt 0) {
+            $cleanedManifest = $matches[0].Groups[1].Value
+
+            # Delete the old MANIFEST.MF entry from the archive
+            $manifestEntry.Delete()
+
+            # Create a fresh entry for the updated MANIFEST.MF
+            $newManifestEntry = $zipArchive.CreateEntry("META-INF/MANIFEST.MF")
+            $writer = New-Object System.IO.StreamWriter($newManifestEntry.Open())
+            $writer.Write($cleanedManifest)
+            $writer.Flush()
+            $writer.Close()
+
+            Write-Host "MANIFEST.MF updated successfully."
+        }
+        else {
+            Write-Host "No extra blank lines found. No changes to MANIFEST.MF."
+        }
+    }
+    else {
+        Write-Host "No MANIFEST.MF found in the JAR (unexpected?)."
+    }
+} finally {
+    # Close out the archive and file streams
+    $zipArchive.Dispose()
+    $fileStream.Dispose()
+}
+
+Write-Host "Done removing signature files from $packagedAgentFile."
 
 Write-Host "Creating the functions.codeless file"
 New-Item -path $PSScriptRoot\agent -type file -name "functions.codeless"

--- a/package-pipeline.ps1
+++ b/package-pipeline.ps1
@@ -41,42 +41,46 @@ if (Test-Path -Path $oldOutput) {
     Remove-Item -Path $oldOutput -Recurse
 }
 
-# local testing cleanup
-$oldExtract = [System.IO.Path]::Combine($PSScriptRoot, "extract")
-if (Test-Path -Path $oldExtract) {
-    Remove-Item -Path $oldExtract -Recurse
-}
-
-$extract = new-item -type directory -force $PSScriptRoot\extract
-if (-not(Test-Path -Path $extract)) {
-    echo "Fail to create a new directory $extract"
-    exit 1
-}
-
-echo "Start extracting content from $ApplicationInsightsAgentFilename to extract folder"
-cd -Path $extract -PassThru
-jar xf $ApplicationInsightsAgentFile
-cd $PSScriptRoot
-echo "Done extracting"
-
-echo "Unsign $ApplicationInsightsAgentFilename"
-Remove-Item $extract\META-INF\MSFTSIG.*
-$manifest = "$extract\META-INF\MANIFEST.MF"
-$newContent = (Get-Content -Raw $manifest | Select-String -Pattern '(?sm)^(.*?\r?\n)\r?\n').Matches[0].Groups[1].Value
-Set-Content -Path $manifest $newContent
+## local testing cleanup
+#$oldExtract = [System.IO.Path]::Combine($PSScriptRoot, "extract")
+#if (Test-Path -Path $oldExtract) {
+#    Remove-Item -Path $oldExtract -Recurse
+#}
+#
+#$extract = new-item -type directory -force $PSScriptRoot\extract
+#if (-not(Test-Path -Path $extract)) {
+#    echo "Fail to create a new directory $extract"
+#    exit 1
+#}
+#
+#echo "Start extracting content from $ApplicationInsightsAgentFile to extract folder"
+#cd -Path $extract -PassThru
+#jar xf $ApplicationInsightsAgentFile
+#cd $PSScriptRoot
+#echo "Done extracting"
+#
+#echo "Unsign $ApplicationInsightsAgentFile"
+#Remove-Item $extract\META-INF\MSFTSIG.*
+#$manifest = "$extract\META-INF\MANIFEST.MF"
+#$newContent = (Get-Content -Raw $manifest | Select-String -Pattern '(?sm)^(.*?\r?\n)\r?\n').Matches[0].Groups[1].Value
+#Set-Content -Path $manifest $newContent
 
 $agent = new-item -type directory -force $PSScriptRoot\agent
 $filename = "applicationinsights-agent.jar"
-$result = [System.IO.Path]::Combine($agent, $filename)
-echo "re-jar $filename"
+#$result = [System.IO.Path]::Combine($agent, $filename)
+#echo "re-jar $filename"
+#
+#cd -Path $extract -PassThru
+#jar cfm $result META-INF/MANIFEST.MF .
+#
+#if (-not(Test-Path -Path $result)) {
+#    echo "Fail to re-archive $filename"
+#    exit 1
+#}
 
-cd -Path $extract -PassThru
-jar cfm $result META-INF/MANIFEST.MF .
+Copy-Item $ApplicationInsightsAgentFile -Destination (Join-Path $agent $filename)
+Write-Host "Agent copied successfully to $agentDir"
 
-if (-not(Test-Path -Path $result)) {
-    echo "Fail to re-archive $filename"
-    exit 1
-}
 Write-Host "Creating the functions.codeless file"
 New-Item -path $PSScriptRoot\agent -type file -name "functions.codeless"
 

--- a/package-pipeline.ps1
+++ b/package-pipeline.ps1
@@ -1,65 +1,91 @@
 param (
-  [string]$buildNumber
+    [string]$buildNumber
 )
 
-# A function that checks exit codes and fails script if an error is found 
+# A helper function that stops the entire script if the last command failed.
 function StopOnFailedExecution {
-  if ($LastExitCode) 
-  {
-    exit $LastExitCode 
-  }
+    if ($LastExitCode) {
+        exit $LastExitCode
+    }
 }
 
-Write-Host "Building azure-functions-java-worker with appinsights profile"
+# --------------------------------------------------------------------
+# Build the azure-functions-java-worker (using the "appinsights" profile)
+# --------------------------------------------------------------------
+Write-Host "=== Building azure-functions-java-worker with 'appinsights' profile ==="
 mvn clean package --no-transfer-progress -B -P appinsights
 StopOnFailedExecution
 
-Write-Host "Creating nuget package Microsoft.Azure.Functions.JavaWorker"
-Write-Host "buildNumber: " $buildNumber
-Get-Command nuget
-StopOnFailedExecution
-remove-item pkg -Recurse -ErrorAction Ignore
-mkdir pkg
-Get-ChildItem -Path .\target\* -Include 'azure*' -Exclude '*shaded.jar','*tests.jar' | %{ Copy-Item $_.FullName .\pkg\azure-functions-java-worker.jar }
-StopOnFailedExecution
-copy-item ./worker.config.json pkg
-copy-item ./tools/AzureFunctionsJavaWorker.nuspec pkg/
-copy-item ./annotationLib pkg/annotationLib -Recurse
+# --------------------------------------------------------------------
+# Prepare the final "pkg" folder and copy core worker artifacts
+# --------------------------------------------------------------------
+Write-Host "`n=== Creating NuGet package: Microsoft.Azure.Functions.JavaWorker ==="
+Write-Host "Using buildNumber: $buildNumber"
 
-# locate the agent jar produced by the `appinsights` Maven profile
-$ApplicationInsightsAgentFile = [System.IO.Path]::Combine($PSScriptRoot, 'target', 'agent', 'applicationinsights-agent.jar')
+# Ensure 'nuget' command is available
+Get-Command nuget | Out-Null
+StopOnFailedExecution
 
-if (!(Test-Path -Path $ApplicationInsightsAgentFile)) {
-    Write-Host "Error: $ApplicationInsightsAgentFile not found."
-    Write-Host "Make sure you enabled the 'appinsights' Maven profile that copies the AI agent to target/agent/."
+Write-Host "Removing old 'pkg' folder (if present)..."
+Remove-Item -Recurse -Force -ErrorAction Ignore .\pkg
+
+Write-Host "Creating new 'pkg' folder..."
+New-Item -ItemType Directory -Path .\pkg | Out-Null
+
+Write-Host "Copying azure-functions-java-worker.jar to 'pkg'..."
+Get-ChildItem -Path .\target\* -Include 'azure*' -Exclude '*shaded.jar','*tests.jar' |
+        ForEach-Object { Copy-Item $_.FullName .\pkg\azure-functions-java-worker.jar }
+StopOnFailedExecution
+
+Write-Host "Copying supporting files into 'pkg' folder..."
+Copy-Item .\worker.config.json .\pkg\
+Copy-Item .\tools\AzureFunctionsJavaWorker.nuspec .\pkg\
+Copy-Item .\annotationLib .\pkg\annotationLib -Recurse
+
+# --------------------------------------------------------------------
+# Locate the Application Insights agent built by the Maven profile
+# --------------------------------------------------------------------
+$AgentSourcePath = Join-Path $PSScriptRoot 'target\agent\applicationinsights-agent.jar'
+if (!(Test-Path -Path $AgentSourcePath)) {
+    Write-Host "`nERROR: Application Insights agent not found at '$AgentSourcePath'."
+    Write-Host "Make sure you enabled the 'appinsights' Maven profile."
     exit 1
 }
 
-# local testing cleanup
-$oldOutput = [System.IO.Path]::Combine($PSScriptRoot, "agent")
-if (Test-Path -Path $oldOutput) {
-    Remove-Item -Path $oldOutput -Recurse
+# --------------------------------------------------------------------
+# Create a local 'agent' folder and copy the agent jar there
+# --------------------------------------------------------------------
+Write-Host "`n=== Setting up the agent folder ==="
+
+$AgentFolder = Join-Path $PSScriptRoot 'agent'
+$AgentFilename = 'applicationinsights-agent.jar'
+$PackagedAgentFile = Join-Path $AgentFolder $AgentFilename
+
+Write-Host "Removing old 'agent' folder (if present)..."
+if (Test-Path -Path $AgentFolder) {
+    Remove-Item -Recurse -Force $AgentFolder
 }
 
-$agent = new-item -type directory -force $PSScriptRoot\agent
-$filename = "applicationinsights-agent.jar"
-$packagedAgentFile = Join-Path $agent $filename
+Write-Host "Creating a new 'agent' folder..."
+New-Item -ItemType Directory -Path $AgentFolder | Out-Null
 
-Copy-Item $ApplicationInsightsAgentFile -Destination $packagedAgentFile
-Write-Host "Agent copied successfully to $packagedAgentFile"
+Write-Host "Copying agent from '$AgentSourcePath' to '$PackagedAgentFile'..."
+Copy-Item $AgentSourcePath -Destination $PackagedAgentFile
+StopOnFailedExecution
 
-# Load the required assembly for ZipArchive
+# --------------------------------------------------------------------
+# Remove signature files and adjust MANIFEST.MF in-place (no full extraction)
+# --------------------------------------------------------------------
+Write-Host "`n=== Removing signature files from '$PackagedAgentFile' ==="
+
+# Load .NET assemblies for ZipArchive on Windows
 Add-Type -AssemblyName System.IO.Compression, System.IO.Compression.FileSystem
 
-Write-Host "Removing signature files from $packagedAgentFile ..."
-
-# Open the jar as a zip archive in "Update" mode
-$fileStream = [System.IO.File]::Open($packagedAgentFile, [System.IO.FileMode]::Open)
+$fileStream = [System.IO.File]::Open($PackagedAgentFile, [System.IO.FileMode]::Open)
 $zipArchive = New-Object System.IO.Compression.ZipArchive($fileStream, [System.IO.Compression.ZipArchiveMode]::Update)
 
 try {
-    # 1) Remove signature files (META-INF/MSFTSIG.*, .SF, .RSA, .DSA)
-    Write-Host "Removing signature files..."
+    Write-Host "Deleting signature files from META-INF..."
     $entriesToRemove = $zipArchive.Entries | Where-Object {
         $_.FullName -like "META-INF/MSFTSIG.*" `
         -or $_.FullName -like "META-INF/*.SF" `
@@ -68,59 +94,66 @@ try {
     }
 
     foreach ($entry in $entriesToRemove) {
-        Write-Host "  Deleting: $($entry.FullName)"
+        Write-Host "  Removing: $($entry.FullName)"
         $entry.Delete()
     }
 
-    # 2) Locate the MANIFEST.MF entry
+    Write-Host "Checking MANIFEST.MF for extra signature references..."
     $manifestEntry = $zipArchive.Entries | Where-Object { $_.FullName -eq "META-INF/MANIFEST.MF" }
     if ($manifestEntry) {
-        Write-Host "Removing signature references from MANIFEST.MF ..."
-
-        # Read the existing manifest
         $reader = New-Object System.IO.StreamReader($manifestEntry.Open())
         $manifestContent = $reader.ReadToEnd()
         $reader.Close()
 
+        # Regex to remove blank line(s) after the main attributes
         $pattern = '(?sm)^(.*?\r?\n)\r?\n'
         $matches = [regex]::Matches($manifestContent, $pattern)
 
         if ($matches.Count -gt 0) {
+            Write-Host "  Removing signature-related lines after main attributes."
             $cleanedManifest = $matches[0].Groups[1].Value
 
-            # Delete the old MANIFEST.MF entry from the archive
             $manifestEntry.Delete()
 
-            # Create a fresh entry for the updated MANIFEST.MF
             $newManifestEntry = $zipArchive.CreateEntry("META-INF/MANIFEST.MF")
             $writer = New-Object System.IO.StreamWriter($newManifestEntry.Open())
             $writer.Write($cleanedManifest)
             $writer.Flush()
             $writer.Close()
 
-            Write-Host "MANIFEST.MF updated successfully."
+            Write-Host "  MANIFEST.MF updated successfully."
         }
         else {
-            Write-Host "No extra blank lines found. No changes to MANIFEST.MF."
+            Write-Host "  No extra blank lines found in MANIFEST.MF."
         }
     }
     else {
         Write-Host "No MANIFEST.MF found in the JAR (unexpected?)."
     }
-} finally {
-    # Close out the archive and file streams
+}
+finally {
+    # Always dispose archive and file streams
     $zipArchive.Dispose()
     $fileStream.Dispose()
 }
 
-Write-Host "Done removing signature files from $packagedAgentFile."
+Write-Host "Done removing signature files from '$PackagedAgentFile'."
 
-Write-Host "Creating the functions.codeless file"
-New-Item -path $PSScriptRoot\agent -type file -name "functions.codeless"
+# --------------------------------------------------------------------
+# Add 'functions.codeless' marker and copy agent folder to 'pkg'
+# --------------------------------------------------------------------
+Write-Host "`n=== Creating 'functions.codeless' marker file ==="
+New-Item -Path $AgentFolder -Name "functions.codeless" -ItemType File | Out-Null
 
-cd $PSScriptRoot
-Copy-Item $PSScriptRoot/agent $PSScriptRoot/pkg/agent -Recurse -Verbose
+Write-Host "Copying 'agent' folder into the 'pkg' folder..."
+Copy-Item $AgentFolder (Join-Path $PSScriptRoot 'pkg\agent') -Recurse -Force -Verbose
 
-set-location pkg
+# --------------------------------------------------------------------
+# Package everything into the final NuGet package
+# --------------------------------------------------------------------
+Write-Host "`n=== Creating the NuGet package ==="
+Push-Location pkg
 nuget pack -Properties version=$buildNumber
-set-location ..
+Pop-Location
+
+Write-Host "`n=== Script completed successfully. NuGet package created. ==="


### PR DESCRIPTION
Update the packaging script to avoid the need to extract the complete JAR before removing the signature files. Instead of extracting the JAR, we now remove the signature files in-place by using a zip utility. This change reduces the time taken to package the worker and also reduces the disk space required to extract the JAR.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)