### PR TITLE
Revert "Bumps gson version in order to work with Spingboot 3.4"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.11.0</version>
+      <version>2.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Reverts Azure/azure-functions-java-worker#799

Upgrading the Gson version to 2.11.0 can cause customers to run into issues similar to this:

https://stackoverflow.com/questions/76778605/inaccessibleobjectexception-while-working-in-gson-2-10-1-with-java-17-and-spring