### PR TITLE
Sdktypes bug fix

### DIFF
--- a/emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Constants.cs
+++ b/emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Constants.cs
@@ -25,6 +25,7 @@ namespace Azure.Functions.Java.Tests.E2E
         public static string InputBindingBlobContainer = "test-input-java-new";
         public static string OutputBindingBlobContainer = "test-output-java-new";
         public static string TriggerInputBindingBlobClientSdk = "test-triggerinput-blobclient";
+        public static string TriggerInputBindingBlobInputBlobClientSdk = "test-triggerinput-blobinput-blobclient";
         public static string TriggerInputBindingBlobContainerClientSdk = "test-triggerinput-blobcontclient";
 
         // Xunit Fixtures and Collections

--- a/emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Helpers/StorageHelpers.cs
+++ b/emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Helpers/StorageHelpers.cs
@@ -85,6 +85,7 @@ namespace Azure.Functions.Java.Tests.E2E
             await ClearBlobContainer(Constants.InputBindingBlobContainer);
             await ClearBlobContainer(Constants.OutputBindingBlobContainer);
             await ClearBlobContainer(Constants.TriggerInputBindingBlobClientSdk);
+            await ClearBlobContainer(Constants.TriggerInputBindingBlobInputBlobClientSdk);
             await ClearBlobContainer(Constants.TriggerInputBindingBlobContainerClientSdk);
         }
 
@@ -94,6 +95,7 @@ namespace Azure.Functions.Java.Tests.E2E
             await CreateBlobContainer(Constants.InputBindingBlobContainer);
             await CreateBlobContainer(Constants.OutputBindingBlobContainer);
             await CreateBlobContainer(Constants.TriggerInputBindingBlobClientSdk);
+            await CreateBlobContainer(Constants.TriggerInputBindingBlobInputBlobClientSdk);
             await CreateBlobContainer(Constants.TriggerInputBindingBlobContainerClientSdk);
         }
 

--- a/emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/StorageEndToEndTests.cs
+++ b/emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/StorageEndToEndTests.cs
@@ -133,6 +133,26 @@ namespace Azure.Functions.Java.Tests.E2E
 
         [Fact]
         [Trait("Category", "SdkTypes")]
+        public async Task BlobTriggerToBlob_FromBlobInput_BlobClient_Succeeds()
+        {
+            string fileName = Guid.NewGuid().ToString();
+
+            //cleanup
+            await StorageHelpers.ClearBlobContainers();
+
+            //Setup
+            await StorageHelpers.CreateBlobContainers();
+
+            //Trigger
+            await StorageHelpers.UpdloadFileToContainer(Constants.TriggerInputBindingBlobInputBlobClientSdk, fileName);
+
+            //Verify
+            string result = await StorageHelpers.DownloadFileFromContainer(Constants.OutputBindingBlobContainer, "testfile");
+            Assert.Equal("Hello World", result);
+        }
+
+        [Fact]
+        [Trait("Category", "SdkTypes")]
         public async Task BlobTriggerToBlob_BlobContainerClient_Succeeds()
         {
             string fileName = Guid.NewGuid().ToString();

--- a/emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/StorageEndToEndTests.cs
+++ b/emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/StorageEndToEndTests.cs
@@ -135,7 +135,7 @@ namespace Azure.Functions.Java.Tests.E2E
         [Trait("Category", "SdkTypes")]
         public async Task BlobTriggerToBlob_FromBlobInput_BlobClient_Succeeds()
         {
-            string fileName = Guid.NewGuid().ToString();
+            string fileName = "testfile";
 
             //cleanup
             await StorageHelpers.ClearBlobContainers();

--- a/emulatedtests/pom.xml
+++ b/emulatedtests/pom.xml
@@ -21,7 +21,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
-		<azure.functions.maven.plugin.version>1.37.1</azure.functions.maven.plugin.version>
+		<azure.functions.maven.plugin.version>1.38.0</azure.functions.maven.plugin.version>
 		<azure.functions.java.library.version>3.1.0</azure.functions.java.library.version>
 		<azure.functions.java.library.sql.version>2.1.0</azure.functions.java.library.sql.version>
 		<durabletask.azure.functions>1.0.0-beta.1</durabletask.azure.functions>

--- a/emulatedtests/src/main/java/com/microsoft/azure/functions/endtoend/BlobTriggerSdkTypesTests.java
+++ b/emulatedtests/src/main/java/com/microsoft/azure/functions/endtoend/BlobTriggerSdkTypesTests.java
@@ -37,6 +37,28 @@ public class BlobTriggerSdkTypesTests {
     /**
      * This function will be invoked when a new or updated blob is detected at the specified path. The blob contents are provided as input to this function.
      */
+    @FunctionName("BlobTriggerUsingBlobInputBlobClientToBlobTest")
+    @StorageAccount("AzureWebJobsStorage")
+    public void BlobTriggerBlobInputToBlobTest_BlobClient(
+            @BlobTrigger(name = "triggerBlob", path = "test-triggerinput-blobinput-blobclient/{name}", dataType = "binary") BlobClient triggerBlobClient,
+            @BlobInput(name = "inputBlob", path = "test-output-java-new/testfile.txt", dataType = "binary") BlobClient outputBlobClient,
+            @BlobOutput(name = "outputBlob", path = "test-output-java-new/testfile.txt", dataType = "binary") OutputBinding<byte[]> outputBlob,
+            final ExecutionContext context
+    ) {
+        context.getLogger().info("BlobTriggerUsingBlobInputBlobClientToBlobTest triggered for blob: " + triggerBlobClient.getBlobName());
+
+        // Download the blob content
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        outputBlobClient.downloadStream(outputStream);
+
+        // Set the downloaded content as output
+        outputBlob.setValue(outputStream.toByteArray());
+        context.getLogger().info("Uploaded blob " + triggerBlobClient.getBlobUrl() + " to container test-output-java-new/testfile.txt");
+    }
+
+    /**
+     * This function will be invoked when a new or updated blob is detected at the specified path. The blob contents are provided as input to this function.
+     */
     @FunctionName("BlobTriggerUsingBlobContainerClientToBlobTest")
     @StorageAccount("AzureWebJobsStorage")
     public void BlobTriggerToBlobTest_BlobContainerClient(

--- a/emulatedtests/src/main/java/com/microsoft/azure/functions/endtoend/BlobTriggerSdkTypesTests.java
+++ b/emulatedtests/src/main/java/com/microsoft/azure/functions/endtoend/BlobTriggerSdkTypesTests.java
@@ -18,7 +18,7 @@ public class BlobTriggerSdkTypesTests {
     @FunctionName("BlobTriggerUsingBlobClientToBlobTest")
     @StorageAccount("AzureWebJobsStorage")
     public void BlobTriggerToBlobTest_BlobClient(
-            @BlobTrigger(name = "triggerBlob", path = "test-triggerinput-blobclient/{name}", dataType = "binary") BlobClient triggerBlobClient,
+            @BlobTrigger(name = "triggerBlob", path = "test-triggerinput-blobclient/{name}") BlobClient triggerBlobClient,
             @BindingName("name") String fileName,
             @BlobOutput(name = "outputBlob", path = "test-output-java-new/testfile.txt", dataType = "binary") OutputBinding<byte[]> outputBlob,
             final ExecutionContext context
@@ -40,8 +40,8 @@ public class BlobTriggerSdkTypesTests {
     @FunctionName("BlobTriggerUsingBlobInputBlobClientToBlobTest")
     @StorageAccount("AzureWebJobsStorage")
     public void BlobTriggerBlobInputToBlobTest_BlobClient(
-            @BlobTrigger(name = "triggerBlob", path = "test-triggerinput-blobinput-blobclient/{name}", dataType = "binary") BlobClient triggerBlobClient,
-            @BlobInput(name = "inputBlob", path = "test-output-java-new/testfile.txt", dataType = "binary") BlobClient outputBlobClient,
+            @BlobTrigger(name = "triggerBlob", path = "test-triggerinput-blobinput-blobclient/{name}") BlobClient triggerBlobClient,
+            @BlobInput(name = "inputBlob", path = "test-triggerinput-blobinput-blobclient/testfile.txt") BlobClient outputBlobClient,
             @BlobOutput(name = "outputBlob", path = "test-output-java-new/testfile.txt", dataType = "binary") OutputBinding<byte[]> outputBlob,
             final ExecutionContext context
     ) {
@@ -62,7 +62,7 @@ public class BlobTriggerSdkTypesTests {
     @FunctionName("BlobTriggerUsingBlobContainerClientToBlobTest")
     @StorageAccount("AzureWebJobsStorage")
     public void BlobTriggerToBlobTest_BlobContainerClient(
-            @BlobTrigger(name = "triggerBlob", path = "test-triggerinput-blobcontclient/{name}", dataType = "binary") BlobContainerClient triggerBlobContainerClient,
+            @BlobTrigger(name = "triggerBlob", path = "test-triggerinput-blobcontclient/{name}") BlobContainerClient triggerBlobContainerClient,
             @BindingName("name") String fileName,
             @BlobOutput(name = "outputBlob", path = "test-output-java-new/testfile.txt", dataType = "binary") OutputBinding<byte[]> outputBlob,
             final ExecutionContext context

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -55,7 +55,6 @@ extends:
           - template: /eng/ci/templates/jobs/run-emulated-tests-windows.yml@self
             parameters:
               poolName: 1es-pool-azfunc-public
-              runSdkTypesTests: ${{ parameters.runSdkTypesTests }}
 
       - stage: TestLinux
         dependsOn: []
@@ -63,4 +62,3 @@ extends:
           - template: /eng/ci/templates/jobs/run-emulated-tests-linux.yml@self
             parameters:
               poolName: 1es-pool-azfunc-public
-              runSdkTypesTests: ${{ parameters.runSdkTypesTests }}

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -24,11 +24,6 @@ resources:
       name: 1ESPipelineTemplates/1ESPipelineTemplates
       ref: refs/tags/release
 
-parameters:
-  - name: runSdkTypesTests
-    type: boolean
-    default: false
-
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
   parameters:

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -15,8 +15,5 @@ jobs:
         java -version
       displayName: 'Check default java version'
     - pwsh: |
-        .\installAdditionsLocally.ps1
-      displayName: 'Install java-additions locally'
-    - pwsh: |
         mvn clean package
       displayName: 'Build java worker'

--- a/eng/ci/templates/jobs/run-emulated-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-linux.yml
@@ -167,6 +167,6 @@ jobs:
             env:
               JAVA_HOME: $(JavaHome)
               AzureWebJobsStorage: "UseDevelopmentStorage=true"
-              ENABLE_SDK_TYPES: "true"
+              JAVA_ENABLE_SDK_TYPES: "true"
             displayName: 'Build & Run tests'
             continueOnError: false

--- a/eng/ci/templates/jobs/run-emulated-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-linux.yml
@@ -87,44 +87,44 @@ jobs:
       - pwsh: |
           .\installAdditionsLocally.ps1
         displayName: 'Install java-additions locally'
-      - pwsh: |
-          if ("$(isTag)"){
-            $buildNumber="$(Build.SourceBranchName)"
-            Write-Host "Found git tag."
-          }
-          else {
-            $buildNumber="$(Build.BuildNumber)-v4"
-            Write-Host "git tag not found. Setting package suffix to '$buildNumber'"
-          }
-          Write-Host "##vso[task.setvariable variable=buildNumber;isOutput=true;]$buildNumber"
-          .\package-pipeline.ps1 -buildNumber $buildNumber
-        displayName: 'Executing build script'
-      - pwsh: |
-          cd ./emulatedtests
-          mvn clean package -DexcludedClassPattern="**/BlobTriggerSdkTypesTests.java" `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
-          Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-emulatedtests"
-        displayName: 'Package Java for E2E'
-      - pwsh: |
-          .\setup-tests-pipeline.ps1
-        displayName: 'Setup test environment -- Install the Core Tools'
-      - bash: |
-          chmod +x ./Azure.Functions.Cli/func
-          chmod +x ./Azure.Functions.Cli/gozip
-          export PATH=$PATH:./Azure.Functions.Cli
-          func --version
-        displayName: 'Setup Core Tools - Linux'
-      - task: DotNetCoreCLI@2
-        retryCountOnTaskFailure: 3
-        inputs:
-          command: 'test'
-          projects: |
-            emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
-          arguments: '--filter "Category!=SdkTypes"'
-        env:
-          JAVA_HOME: $(JavaHome)
-          AzureWebJobsStorage: "UseDevelopmentStorage=true"
-        displayName: 'Build & Run tests'
-        continueOnError: false
+#      - pwsh: |
+#          if ("$(isTag)"){
+#            $buildNumber="$(Build.SourceBranchName)"
+#            Write-Host "Found git tag."
+#          }
+#          else {
+#            $buildNumber="$(Build.BuildNumber)-v4"
+#            Write-Host "git tag not found. Setting package suffix to '$buildNumber'"
+#          }
+#          Write-Host "##vso[task.setvariable variable=buildNumber;isOutput=true;]$buildNumber"
+#          .\package-pipeline.ps1 -buildNumber $buildNumber
+#        displayName: 'Executing build script'
+#      - pwsh: |
+#          cd ./emulatedtests
+#          mvn clean package -DexcludedClassPattern="**/BlobTriggerSdkTypesTests.java" `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
+#          Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-emulatedtests"
+#        displayName: 'Package Java for E2E'
+#      - pwsh: |
+#          .\setup-tests-pipeline.ps1
+#        displayName: 'Setup test environment -- Install the Core Tools'
+#      - bash: |
+#          chmod +x ./Azure.Functions.Cli/func
+#          chmod +x ./Azure.Functions.Cli/gozip
+#          export PATH=$PATH:./Azure.Functions.Cli
+#          func --version
+#        displayName: 'Setup Core Tools - Linux'
+#      - task: DotNetCoreCLI@2
+#        retryCountOnTaskFailure: 3
+#        inputs:
+#          command: 'test'
+#          projects: |
+#            emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
+#          arguments: '--filter "Category!=SdkTypes"'
+#        env:
+#          JAVA_HOME: $(JavaHome)
+#          AzureWebJobsStorage: "UseDevelopmentStorage=true"
+#        displayName: 'Build & Run tests'
+#        continueOnError: false
       # ------------------------------------------
       # Conditionally run an additional set of steps for "SDK types" scenario
       # ------------------------------------------

--- a/eng/ci/templates/jobs/run-emulated-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-linux.yml
@@ -34,16 +34,16 @@ jobs:
           JAVA_VERSION: 'microsoft-jdk-11.0.21-linux-x64'
           JDK_PATH: 'jdk-11.0.21+9'
           JAVA_VERSION_SPEC: '11'
-#        microsoft-open-jdk-17-linux:
-#          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-17.0.9-linux-x64.tar.gz'
-#          JAVA_VERSION: 'microsoft-jdk-17.0.9-linux-x64'
-#          JDK_PATH: 'jdk-17.0.9+8'
-#          JAVA_VERSION_SPEC: '17'
-#        microsoft-open-jdk-21-linux:
-#          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-21.0.1-linux-x64.tar.gz'
-#          JAVA_VERSION: 'microsoft-jdk-21.0.1-linux-x64'
-#          JDK_PATH: 'jdk-21.0.1+12'
-#          JAVA_VERSION_SPEC: '21'
+        microsoft-open-jdk-17-linux:
+          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-17.0.9-linux-x64.tar.gz'
+          JAVA_VERSION: 'microsoft-jdk-17.0.9-linux-x64'
+          JDK_PATH: 'jdk-17.0.9+8'
+          JAVA_VERSION_SPEC: '17'
+        microsoft-open-jdk-21-linux:
+          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-21.0.1-linux-x64.tar.gz'
+          JAVA_VERSION: 'microsoft-jdk-21.0.1-linux-x64'
+          JDK_PATH: 'jdk-21.0.1+12'
+          JAVA_VERSION_SPEC: '21'
 
     steps:
       - task: NuGetToolInstaller@1
@@ -87,44 +87,44 @@ jobs:
       - pwsh: |
           .\installAdditionsLocally.ps1
         displayName: 'Install java-additions locally'
-#      - pwsh: |
-#          if ("$(isTag)"){
-#            $buildNumber="$(Build.SourceBranchName)"
-#            Write-Host "Found git tag."
-#          }
-#          else {
-#            $buildNumber="$(Build.BuildNumber)-v4"
-#            Write-Host "git tag not found. Setting package suffix to '$buildNumber'"
-#          }
-#          Write-Host "##vso[task.setvariable variable=buildNumber;isOutput=true;]$buildNumber"
-#          .\package-pipeline.ps1 -buildNumber $buildNumber
-#        displayName: 'Executing build script'
-#      - pwsh: |
-#          cd ./emulatedtests
-#          mvn clean package -DexcludedClassPattern="**/BlobTriggerSdkTypesTests.java" `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
-#          Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-emulatedtests"
-#        displayName: 'Package Java for E2E'
-#      - pwsh: |
-#          .\setup-tests-pipeline.ps1
-#        displayName: 'Setup test environment -- Install the Core Tools'
-#      - bash: |
-#          chmod +x ./Azure.Functions.Cli/func
-#          chmod +x ./Azure.Functions.Cli/gozip
-#          export PATH=$PATH:./Azure.Functions.Cli
-#          func --version
-#        displayName: 'Setup Core Tools - Linux'
-#      - task: DotNetCoreCLI@2
-#        retryCountOnTaskFailure: 3
-#        inputs:
-#          command: 'test'
-#          projects: |
-#            emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
-#          arguments: '--filter "Category!=SdkTypes"'
-#        env:
-#          JAVA_HOME: $(JavaHome)
-#          AzureWebJobsStorage: "UseDevelopmentStorage=true"
-#        displayName: 'Build & Run tests'
-#        continueOnError: false
+      - pwsh: |
+          if ("$(isTag)"){
+            $buildNumber="$(Build.SourceBranchName)"
+            Write-Host "Found git tag."
+          }
+          else {
+            $buildNumber="$(Build.BuildNumber)-v4"
+            Write-Host "git tag not found. Setting package suffix to '$buildNumber'"
+          }
+          Write-Host "##vso[task.setvariable variable=buildNumber;isOutput=true;]$buildNumber"
+          .\package-pipeline.ps1 -buildNumber $buildNumber
+        displayName: 'Executing build script'
+      - pwsh: |
+          cd ./emulatedtests
+          mvn clean package -DexcludedClassPattern="**/BlobTriggerSdkTypesTests.java" `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
+          Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-emulatedtests"
+        displayName: 'Package Java for E2E'
+      - pwsh: |
+          .\setup-tests-pipeline.ps1
+        displayName: 'Setup test environment -- Install the Core Tools'
+      - bash: |
+          chmod +x ./Azure.Functions.Cli/func
+          chmod +x ./Azure.Functions.Cli/gozip
+          export PATH=$PATH:./Azure.Functions.Cli
+          func --version
+        displayName: 'Setup Core Tools - Linux'
+      - task: DotNetCoreCLI@2
+        retryCountOnTaskFailure: 3
+        inputs:
+          command: 'test'
+          projects: |
+            emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
+          arguments: '--filter "Category!=SdkTypes"'
+        env:
+          JAVA_HOME: $(JavaHome)
+          AzureWebJobsStorage: "UseDevelopmentStorage=true"
+        displayName: 'Build & Run tests'
+        continueOnError: false
       # ------------------------------------------
       # Conditionally run an additional set of steps for "SDK types" scenario
       # ------------------------------------------

--- a/eng/ci/templates/jobs/run-emulated-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-linux.yml
@@ -114,7 +114,6 @@ jobs:
           projects: |
             emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
         env:
-          JAVA_HOME: $(JavaHome)
           AzureWebJobsStorage: "UseDevelopmentStorage=true"
           JAVA_ENABLE_SDK_TYPES: "true"
         displayName: 'Build & Run tests'

--- a/eng/ci/templates/jobs/run-emulated-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-linux.yml
@@ -2,9 +2,6 @@ parameters:
   - name: poolName
     type: string
     default: ''
-  - name: runSdkTypesTests
-    type: boolean
-    default: false
 
 jobs:
   - job: "TestLinux"
@@ -101,7 +98,7 @@ jobs:
         displayName: 'Executing build script'
       - pwsh: |
           cd ./emulatedtests
-          mvn clean package -DexcludedClassPattern="**/BlobTriggerSdkTypesTests.java" `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
+          mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
           Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-emulatedtests"
         displayName: 'Package Java for E2E'
       - pwsh: |
@@ -119,51 +116,9 @@ jobs:
           command: 'test'
           projects: |
             emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
-          arguments: '--filter "Category!=SdkTypes"'
         env:
           JAVA_HOME: $(JavaHome)
           AzureWebJobsStorage: "UseDevelopmentStorage=true"
+          JAVA_ENABLE_SDK_TYPES: "true"
         displayName: 'Build & Run tests'
         continueOnError: false
-      # ------------------------------------------
-      # Conditionally run an additional set of steps for "SDK types" scenario
-      # ------------------------------------------
-      - ${{ if eq(parameters.runSdkTypesTests, true) }}:
-          - pwsh: |
-              if ("$(isTag)"){
-                $buildNumber="$(Build.SourceBranchName)"
-                Write-Host "Found git tag."
-              }
-              else {
-                $buildNumber="$(Build.BuildNumber)-v4"
-                Write-Host "git tag not found. Setting package suffix to '$buildNumber'"
-              }
-              Write-Host "##vso[task.setvariable variable=buildNumber;isOutput=true;]$buildNumber"
-              .\package-pipeline.ps1 -buildNumber $buildNumber
-            displayName: 'Executing build script'
-          - pwsh: |
-              cd ./emulatedtests
-              mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
-              Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-emulatedtests"
-            displayName: 'Package Java for E2E'
-          - pwsh: |
-              .\setup-tests-pipeline.ps1
-            displayName: 'Setup test environment -- Install the Core Tools'
-          - bash: |
-              chmod +x ./Azure.Functions.Cli/func
-              chmod +x ./Azure.Functions.Cli/gozip
-              export PATH=$PATH:./Azure.Functions.Cli
-              func --version
-            displayName: 'Setup Core Tools - Linux'
-          - task: DotNetCoreCLI@2
-            retryCountOnTaskFailure: 3
-            inputs:
-              command: 'test'
-              projects: |
-                emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
-            env:
-              JAVA_HOME: $(JavaHome)
-              AzureWebJobsStorage: "UseDevelopmentStorage=true"
-              JAVA_ENABLE_SDK_TYPES: "true"
-            displayName: 'Build & Run tests'
-            continueOnError: false

--- a/eng/ci/templates/jobs/run-emulated-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-linux.yml
@@ -82,9 +82,6 @@ jobs:
           docker compose -f emulatedtests/utils/docker-compose.yml up -d
         displayName: 'Install Azurite and Start Emulators'
       - pwsh: |
-          .\installAdditionsLocally.ps1
-        displayName: 'Install java-additions locally'
-      - pwsh: |
           if ("$(isTag)"){
             $buildNumber="$(Build.SourceBranchName)"
             Write-Host "Found git tag."

--- a/eng/ci/templates/jobs/run-emulated-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-linux.yml
@@ -130,9 +130,6 @@ jobs:
       # ------------------------------------------
       - ${{ if eq(parameters.runSdkTypesTests, true) }}:
           - pwsh: |
-              .\installMavenPluginLocally.ps1
-            displayName: 'Install maven plugin locally'
-          - pwsh: |
               if ("$(isTag)"){
                 $buildNumber="$(Build.SourceBranchName)"
                 Write-Host "Found git tag."

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -63,7 +63,7 @@ jobs:
           versionSpec: $(JAVA_VERSION_SPEC)
           jdkArchitectureOption: 'x64'
           jdkSourceOption: LocalDirectory
-          jdkFile: "$(downloadPath)/$(JAVA_VERSION).tar.gz"
+          jdkFile: "$(downloadPath)/$(JAVA_VERSION).zip"
           jdkDestinationDirectory: "$(downloadPath)/externals"
           cleanDestinationDirectory: true
         displayName: 'Setup Java for Windows'

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -53,14 +53,20 @@ jobs:
         displayName: 'Install .NET 6'
         inputs:
           version: 6.0.x
-      - pwsh: |
-          Invoke-WebRequest $(JDK_DOWNLOAD_LINK) -OutFile "$(JAVA_VERSION).zip"
-          Expand-Archive -Force "$(JAVA_VERSION).zip" .
-          cd $(JDK_PATH)
+      - pwsh: | # Download JDK for later installation
+          Invoke-WebRequest $(JDK_DOWNLOAD_LINK) -OutFile "$(JAVA_VERSION).tar.gz"
           $current = get-location | select -ExpandProperty Path
-          cd ..
-          Write-Host "##vso[task.setvariable variable=JavaHome;]$current"
-        displayName: 'Download and setup Java for Windows'
+          Write-Host "##vso[task.setvariable variable=downloadPath;]$current"
+        displayName: 'Download jdk for Windows'
+      - task: JavaToolInstaller@0 # Install JDK downloaded from previous task
+        inputs:
+          versionSpec: $(JAVA_VERSION_SPEC)
+          jdkArchitectureOption: 'x64'
+          jdkSourceOption: LocalDirectory
+          jdkFile: "$(downloadPath)/$(JAVA_VERSION).tar.gz"
+          jdkDestinationDirectory: "$(downloadPath)/externals"
+          cleanDestinationDirectory: true
+        displayName: 'Setup Java for Windows'
       - bash: |
           npm install -g azurite
           mkdir azurite

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -115,9 +115,6 @@ jobs:
       # ------------------------------------------
       - ${{ if eq(parameters.runSdkTypesTests, true) }}:
           - pwsh: |
-              .\installMavenPluginLocally.ps1
-            displayName: 'Install maven plugin locally'
-          - pwsh: |
               if ("$(isTag)"){
                 $buildNumber="$(Build.SourceBranchName)"
                 Write-Host "Found git tag."

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -2,9 +2,6 @@ parameters:
   - name: poolName
     type: string
     default: ''
-  - name: runSdkTypesTests
-    type: boolean
-    default: false
 
 jobs:
   - job: "TestWindows"
@@ -86,7 +83,7 @@ jobs:
         displayName: 'Executing build script'
       - pwsh: |
           cd ./emulatedtests
-          mvn clean package -DexcludedClassPattern="**/BlobTriggerSdkTypesTests.java" `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
+          mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
           Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-emulatedtests"
         displayName: 'Package Java for E2E'
       - pwsh: |
@@ -103,51 +100,9 @@ jobs:
           command: 'test'
           projects: |
             emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
-          arguments: '--filter "Category!=SdkTypes"'
         env:
           JAVA_HOME: $(JavaHome)
           AzureWebJobsStorage: "UseDevelopmentStorage=true"
-          ENABLE_SDK_TYPES: "true"
+          JAVA_ENABLE_SDK_TYPES: "true"
         displayName: 'Build & Run tests'
         continueOnError: false
-      # ------------------------------------------
-      # Conditionally run an additional set of steps for "SDK types" scenario
-      # ------------------------------------------
-      - ${{ if eq(parameters.runSdkTypesTests, true) }}:
-          - pwsh: |
-              if ("$(isTag)"){
-                $buildNumber="$(Build.SourceBranchName)"
-                Write-Host "Found git tag."
-              }
-              else {
-                $buildNumber="$(Build.BuildNumber)-v4"
-                Write-Host "git tag not found. Setting package suffix to '$buildNumber'"
-              }
-              Write-Host "##vso[task.setvariable variable=buildNumber;isOutput=true;]$buildNumber"
-              .\package-pipeline.ps1 -buildNumber $buildNumber
-            displayName: 'Executing build script (SDK types)'
-          - pwsh: |
-              cd ./emulatedtests
-              mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
-              Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-emulatedtests"
-            displayName: 'Package Java for E2E (SDK types)'
-          - pwsh: |
-              .\setup-tests-pipeline.ps1
-            displayName: 'Setup test environment -- Install the Core Tools'
-          - pwsh: |
-              $currDir =  Get-Location
-              $Env:Path = $Env:Path+";$currDir/Azure.Functions.Cli"
-              func --version
-            displayName: 'Setup Core Tools - Windows'
-          - task: DotNetCoreCLI@2
-            retryCountOnTaskFailure: 3
-            inputs:
-              command: 'test'
-              projects: |
-                emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
-            env:
-              JAVA_HOME: $(JavaHome)
-              AzureWebJobsStorage: "UseDevelopmentStorage=true"
-              JAVA_ENABLE_SDK_TYPES: "true"
-            displayName: 'Build & Run tests (SDK types)'
-            continueOnError: false

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -71,10 +71,11 @@ jobs:
           jdkDestinationDirectory: "$(downloadPath)/externals"
           cleanDestinationDirectory: true
         displayName: 'Setup Java for Windows'
-      - pwsh: |
-          docker compose -f emulatedtests/utils/docker-compose.yml pull
-          docker compose -f emulatedtests/utils/docker-compose.yml up -d
-        displayName: 'Install Azurite and Start Emulators'
+      - bash: |
+          npm install -g azurite
+          mkdir azurite
+          azurite --silent --location azurite --debug azurite\debug.log &
+        displayName: 'Install and Run Azurite'
       - pwsh: |
           if ("$(isTag)"){
             $buildNumber="$(Build.SourceBranchName)"

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -104,7 +104,6 @@ jobs:
           projects: |
             emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
         env:
-          JAVA_HOME: $(JavaHome)
           AzureWebJobsStorage: "UseDevelopmentStorage=true"
           JAVA_ENABLE_SDK_TYPES: "true"
         displayName: 'Build & Run tests'

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -72,44 +72,44 @@ jobs:
       - pwsh: |
           .\installAdditionsLocally.ps1
         displayName: 'Install java-additions locally'
-#      - pwsh: |
-#          if ("$(isTag)"){
-#            $buildNumber="$(Build.SourceBranchName)"
-#            Write-Host "Found git tag."
-#          }
-#          else {
-#            $buildNumber="$(Build.BuildNumber)-v4"
-#            Write-Host "git tag not found. Setting package suffix to '$buildNumber'"
-#          }
-#          Write-Host "##vso[task.setvariable variable=buildNumber;isOutput=true;]$buildNumber"
-#          .\package-pipeline.ps1 -buildNumber $buildNumber
-#        displayName: 'Executing build script'
-#      - pwsh: |
-#          cd ./emulatedtests
-#          mvn clean package -DexcludedClassPattern="**/BlobTriggerSdkTypesTests.java" `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
-#          Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-emulatedtests"
-#        displayName: 'Package Java for E2E'
-#      - pwsh: |
-#          .\setup-tests-pipeline.ps1
-#        displayName: 'Setup test environment -- Install the Core Tools'
-#      - pwsh: |
-#          $currDir =  Get-Location
-#          $Env:Path = $Env:Path+";$currDir/Azure.Functions.Cli"
-#          func --version
-#        displayName: 'Setup Core Tools - Windows'
-#      - task: DotNetCoreCLI@2
-#        retryCountOnTaskFailure: 3
-#        inputs:
-#          command: 'test'
-#          projects: |
-#            emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
-#          arguments: '--filter "Category!=SdkTypes"'
-#        env:
-#          JAVA_HOME: $(JavaHome)
-#          AzureWebJobsStorage: "UseDevelopmentStorage=true"
-#          ENABLE_SDK_TYPES: "true"
-#        displayName: 'Build & Run tests'
-#        continueOnError: false
+      - pwsh: |
+          if ("$(isTag)"){
+            $buildNumber="$(Build.SourceBranchName)"
+            Write-Host "Found git tag."
+          }
+          else {
+            $buildNumber="$(Build.BuildNumber)-v4"
+            Write-Host "git tag not found. Setting package suffix to '$buildNumber'"
+          }
+          Write-Host "##vso[task.setvariable variable=buildNumber;isOutput=true;]$buildNumber"
+          .\package-pipeline.ps1 -buildNumber $buildNumber
+        displayName: 'Executing build script'
+      - pwsh: |
+          cd ./emulatedtests
+          mvn clean package -DexcludedClassPattern="**/BlobTriggerSdkTypesTests.java" `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
+          Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-emulatedtests"
+        displayName: 'Package Java for E2E'
+      - pwsh: |
+          .\setup-tests-pipeline.ps1
+        displayName: 'Setup test environment -- Install the Core Tools'
+      - pwsh: |
+          $currDir =  Get-Location
+          $Env:Path = $Env:Path+";$currDir/Azure.Functions.Cli"
+          func --version
+        displayName: 'Setup Core Tools - Windows'
+      - task: DotNetCoreCLI@2
+        retryCountOnTaskFailure: 3
+        inputs:
+          command: 'test'
+          projects: |
+            emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
+          arguments: '--filter "Category!=SdkTypes"'
+        env:
+          JAVA_HOME: $(JavaHome)
+          AzureWebJobsStorage: "UseDevelopmentStorage=true"
+          ENABLE_SDK_TYPES: "true"
+        displayName: 'Build & Run tests'
+        continueOnError: false
       # ------------------------------------------
       # Conditionally run an additional set of steps for "SDK types" scenario
       # ------------------------------------------

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -25,18 +25,22 @@ jobs:
           JDK_DOWNLOAD_LINK: 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u392b08.zip'
           JAVA_VERSION: 'OpenJDK8U-jdk_x64_windows_hotspot_8u392b08'
           JDK_PATH: 'jdk8u392-b08'
+          JAVA_VERSION_SPEC: '8'
         microsoft-open-jdk-11-windows:
           JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-11.0.21-windows-x64.zip'
           JAVA_VERSION: 'microsoft-jdk-11.0.21-windows-x64'
           JDK_PATH: 'jdk-11.0.21+9'
+          JAVA_VERSION_SPEC: '11'
         microsoft-open-jdk-17-windows:
           JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-17.0.9-windows-x64.zip'
           JAVA_VERSION: 'microsoft-jdk-17.0.9-windows-x64'
           JDK_PATH: 'jdk-17.0.9+8'
+          JAVA_VERSION_SPEC: '17'
         microsoft-open-jdk-21-windows:
           JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-21.0.1-windows-x64.zip'
           JAVA_VERSION: 'microsoft-jdk-21.0.1-windows-x64'
           JDK_PATH: 'jdk-21.0.1+12'
+          JAVA_VERSION_SPEC: '21'
 
     steps:
       - task: NuGetToolInstaller@1

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -151,6 +151,6 @@ jobs:
             env:
               JAVA_HOME: $(JavaHome)
               AzureWebJobsStorage: "UseDevelopmentStorage=true"
-              ENABLE_SDK_TYPES: "true"
+              JAVA_ENABLE_SDK_TYPES: "true"
             displayName: 'Build & Run tests (SDK types)'
             continueOnError: false

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -71,11 +71,10 @@ jobs:
           jdkDestinationDirectory: "$(downloadPath)/externals"
           cleanDestinationDirectory: true
         displayName: 'Setup Java for Windows'
-      - bash: |
-          npm install -g azurite
-          mkdir azurite
-          azurite --silent --location azurite --debug azurite\debug.log &
-        displayName: 'Install and Run Azurite'
+      - pwsh: |
+          docker compose -f emulatedtests/utils/docker-compose.yml pull
+          docker compose -f emulatedtests/utils/docker-compose.yml up -d
+        displayName: 'Install Azurite and Start Emulators'
       - pwsh: |
           if ("$(isTag)"){
             $buildNumber="$(Build.SourceBranchName)"

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -54,7 +54,7 @@ jobs:
         inputs:
           version: 6.0.x
       - pwsh: | # Download JDK for later installation
-          Invoke-WebRequest $(JDK_DOWNLOAD_LINK) -OutFile "$(JAVA_VERSION).tar.gz"
+          Invoke-WebRequest $(JDK_DOWNLOAD_LINK) -OutFile "$(JAVA_VERSION).zip"
           $current = get-location | select -ExpandProperty Path
           Write-Host "##vso[task.setvariable variable=downloadPath;]$current"
         displayName: 'Download jdk for Windows'

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -67,9 +67,6 @@ jobs:
           azurite --silent --location azurite --debug azurite\debug.log &
         displayName: 'Install and Run Azurite'
       - pwsh: |
-          .\installAdditionsLocally.ps1
-        displayName: 'Install java-additions locally'
-      - pwsh: |
           if ("$(isTag)"){
             $buildNumber="$(Build.SourceBranchName)"
             Write-Host "Found git tag."

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -72,44 +72,44 @@ jobs:
       - pwsh: |
           .\installAdditionsLocally.ps1
         displayName: 'Install java-additions locally'
-      - pwsh: |
-          if ("$(isTag)"){
-            $buildNumber="$(Build.SourceBranchName)"
-            Write-Host "Found git tag."
-          }
-          else {
-            $buildNumber="$(Build.BuildNumber)-v4"
-            Write-Host "git tag not found. Setting package suffix to '$buildNumber'"
-          }
-          Write-Host "##vso[task.setvariable variable=buildNumber;isOutput=true;]$buildNumber"
-          .\package-pipeline.ps1 -buildNumber $buildNumber
-        displayName: 'Executing build script'
-      - pwsh: |
-          cd ./emulatedtests
-          mvn clean package -DexcludedClassPattern="**/BlobTriggerSdkTypesTests.java" `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
-          Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-emulatedtests"
-        displayName: 'Package Java for E2E'
-      - pwsh: |
-          .\setup-tests-pipeline.ps1
-        displayName: 'Setup test environment -- Install the Core Tools'
-      - pwsh: |
-          $currDir =  Get-Location
-          $Env:Path = $Env:Path+";$currDir/Azure.Functions.Cli"
-          func --version
-        displayName: 'Setup Core Tools - Windows'
-      - task: DotNetCoreCLI@2
-        retryCountOnTaskFailure: 3
-        inputs:
-          command: 'test'
-          projects: |
-            emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
-          arguments: '--filter "Category!=SdkTypes"'
-        env:
-          JAVA_HOME: $(JavaHome)
-          AzureWebJobsStorage: "UseDevelopmentStorage=true"
-          ENABLE_SDK_TYPES: "true"
-        displayName: 'Build & Run tests'
-        continueOnError: false
+#      - pwsh: |
+#          if ("$(isTag)"){
+#            $buildNumber="$(Build.SourceBranchName)"
+#            Write-Host "Found git tag."
+#          }
+#          else {
+#            $buildNumber="$(Build.BuildNumber)-v4"
+#            Write-Host "git tag not found. Setting package suffix to '$buildNumber'"
+#          }
+#          Write-Host "##vso[task.setvariable variable=buildNumber;isOutput=true;]$buildNumber"
+#          .\package-pipeline.ps1 -buildNumber $buildNumber
+#        displayName: 'Executing build script'
+#      - pwsh: |
+#          cd ./emulatedtests
+#          mvn clean package -DexcludedClassPattern="**/BlobTriggerSdkTypesTests.java" `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
+#          Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-emulatedtests"
+#        displayName: 'Package Java for E2E'
+#      - pwsh: |
+#          .\setup-tests-pipeline.ps1
+#        displayName: 'Setup test environment -- Install the Core Tools'
+#      - pwsh: |
+#          $currDir =  Get-Location
+#          $Env:Path = $Env:Path+";$currDir/Azure.Functions.Cli"
+#          func --version
+#        displayName: 'Setup Core Tools - Windows'
+#      - task: DotNetCoreCLI@2
+#        retryCountOnTaskFailure: 3
+#        inputs:
+#          command: 'test'
+#          projects: |
+#            emulatedtests/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E/Azure.Functions.Java.Tests.E2E.csproj
+#          arguments: '--filter "Category!=SdkTypes"'
+#        env:
+#          JAVA_HOME: $(JavaHome)
+#          AzureWebJobsStorage: "UseDevelopmentStorage=true"
+#          ENABLE_SDK_TYPES: "true"
+#        displayName: 'Build & Run tests'
+#        continueOnError: false
       # ------------------------------------------
       # Conditionally run an additional set of steps for "SDK types" scenario
       # ------------------------------------------

--- a/eng/ci/templates/official/jobs/build-artifacts.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts.yml
@@ -39,9 +39,6 @@ jobs:
           java -version
         displayName: 'Check default java version'
       - pwsh: |
-          .\installAdditionsLocally.ps1
-        displayName: 'Install java-additions locally'
-      - pwsh: |
           if ("$(isRelease)"){
             $buildNumber="$(Build.SourceBranchName)"
             Write-Host "Triggered for release."

--- a/pom.xml
+++ b/pom.xml
@@ -439,6 +439,8 @@
             <configuration>
               <argLine>
                 --add-opens java.base/java.lang=ALL-UNNAMED
+                --add-opens java.base/java.util=ALL-UNNAMED
+                --add-opens java.base/java.lang.reflect=ALL-UNNAMED
               </argLine>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <azure.functions.java.core.library.version>1.3.0</azure.functions.java.core.library.version>
     <azure.functions.java.spi>1.1.0</azure.functions.java.spi>
-    <azure.functions.java.sdktypes>1.0.0</azure.functions.java.sdktypes>
+    <azure.functions.java.sdktypes>1.0.1</azure.functions.java.sdktypes>
     <azure.functions.java.library.version>2.2.0</azure.functions.java.library.version>
     <jupiter.version>5.9.1</jupiter.version>
     <mockito-core.version>4.11.0</mockito-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <azure.functions.java.sdktypes>1.0.1</azure.functions.java.sdktypes>
     <azure.functions.java.library.version>2.2.0</azure.functions.java.library.version>
     <jupiter.version>5.9.1</jupiter.version>
-    <mockito-core.version>5.18.0</mockito-core.version>
+    <mockito-core.version>4.11.0</mockito-core.version>
     <appinsights.agents.version>3.7.2</appinsights.agents.version>
   </properties>
   <licenses>
@@ -428,7 +428,9 @@
         <!-- activates when the running JDK is 17 or newer -->
         <jdk>[17,)</jdk>
       </activation>
-
+      <properties>
+        <mockito-core.version>5.18.0</mockito-core.version>
+      </properties>
       <build>
         <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <azure.functions.java.sdktypes>1.0.1</azure.functions.java.sdktypes>
     <azure.functions.java.library.version>2.2.0</azure.functions.java.library.version>
     <jupiter.version>5.9.1</jupiter.version>
-    <mockito-core.version>4.11.0</mockito-core.version>
+    <mockito-core.version>5.18.0</mockito-core.version>
     <appinsights.agents.version>3.7.2</appinsights.agents.version>
   </properties>
   <licenses>
@@ -308,7 +308,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.1</version>
+        <version>3.5.3</version>
         <configuration>
           <workingDirectory>${project.build.directory}</workingDirectory>
           <systemProperties>
@@ -418,6 +418,27 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk-17-plus</id>
+      <activation>
+        <!-- activates when the running JDK is 17 or newer -->
+        <jdk>[17,)</jdk>
+      </activation>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>
+                --add-opens java.base/java.lang=ALL-UNNAMED
+              </argLine>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/src/main/java/com/microsoft/azure/functions/worker/Constants.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/Constants.java
@@ -17,4 +17,5 @@ public final class Constants {
     public final static String HAS_IMPLICIT_OUTPUT_QUALIFIED_NAME = "com.microsoft.azure.functions.annotation.HasImplicitOutput";
     public static final String JAVA_ENABLE_OPENTELEMETRY = "JAVA_ENABLE_OPENTELEMETRY";
     public static final String JAVA_APPLICATIONINSIGHTS_ENABLE_TELEMETRY = "JAVA_APPLICATIONINSIGHTS_ENABLE_TELEMETRY";
+    public static final String JAVA_ENABLE_SDK_TYPES = "JAVA_ENABLE_SDK_TYPES";
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/binding/BindingDataStore.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/binding/BindingDataStore.java
@@ -54,16 +54,9 @@ public final class BindingDataStore {
     public Optional<BindingData> getDataByName(String name, Type target) {
         DataSource<?> parameterDataSource = this.inputSources.get(name);
         if (parameterDataSource == null) {
-            Optional<Map.Entry<String, DataSource<?>>> firstEntry = this.inputSources.entrySet().stream().findFirst();
-            if (firstEntry.isPresent()) {
-                DataSource<?> subDict = firstEntry.get().getValue();
-                return subDict.computeByName(name, target);
-            }
-        }
-        if (parameterDataSource == null) {
             throw new RuntimeException("Cannot find matched parameter name of customer function, please check if customer function is defined correctly");
         }
-    	return parameterDataSource.computeByName(name, target);
+        return parameterDataSource.computeByName(name, target);
     }
 
     public Optional<BindingData> getDataByNameFromInputSource(String name, Type target, String inputSourceName) {

--- a/src/main/java/com/microsoft/azure/functions/worker/binding/BindingDataStore.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/binding/BindingDataStore.java
@@ -60,12 +60,8 @@ public final class BindingDataStore {
     }
 
     public Optional<BindingData> getDataByNameFromInputSource(String name, Type target, String inputSourceName) {
-        Optional<DataSource<?>> inputSourceDict = Optional.ofNullable(this.inputSources.get(inputSourceName));
-        if (inputSourceDict.isPresent()) {
-            return inputSourceDict.get().computeByName(name, target);
-        }
-
-        return Optional.empty();
+        return Optional.ofNullable(this.inputSources.get(inputSourceName))
+               .flatMap(ds -> ds.computeByName(name, target));
     }
 
     public Optional<BindingData> getTriggerMetatDataByName(String name, Type target) {

--- a/src/main/java/com/microsoft/azure/functions/worker/binding/BindingDataStore.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/binding/BindingDataStore.java
@@ -66,6 +66,15 @@ public final class BindingDataStore {
     	return parameterDataSource.computeByName(name, target);
     }
 
+    public Optional<BindingData> getDataByNameFromInputSource(String name, Type target, String inputSourceName) {
+        Optional<DataSource<?>> inputSourceDict = Optional.ofNullable(this.inputSources.get(inputSourceName));
+        if (inputSourceDict.isPresent()) {
+            return inputSourceDict.get().computeByName(name, target);
+        }
+
+        return Optional.empty();
+    }
+
     public Optional<BindingData> getTriggerMetatDataByName(String name, Type target) {
         DataSource<?> metadataDataSource = this.metadataSources.get(name);
         if (metadataDataSource == null) {

--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
@@ -28,6 +28,8 @@ import com.microsoft.azure.functions.sdktype.SdkParameterAnalyzer;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
+import static com.microsoft.azure.functions.worker.Constants.JAVA_ENABLE_SDK_TYPES;
+
 /**
  * A broker between JAR methods and the function RPC. It can load methods using
  * reflection, and invoke them at runtime. Thread-Safety: Multiple thread.
@@ -47,7 +49,7 @@ public class JavaFunctionBroker {
 	private final SdkParameterAnalyzer sdkParameterAnalyzer = new SdkParameterAnalyzer();
 	private final WorkerObjectCache<CacheKey> workerObjectCache;
 	private static final boolean JAVA_ENABLE_SDK_TYPES_FLAG =
-			Boolean.parseBoolean(System.getenv("JAVA_ENABLE_SDK_TYPES"));
+			Boolean.parseBoolean(System.getenv(JAVA_ENABLE_SDK_TYPES));
 	private ClassLoader userContextClassLoader;
 
 	private FunctionInstanceInjector newInstanceInjector() {

--- a/src/main/java/com/microsoft/azure/functions/worker/chain/SdkTypeMiddleware.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/chain/SdkTypeMiddleware.java
@@ -65,6 +65,7 @@ public class SdkTypeMiddleware implements Middleware {
                     metaData.setFieldValue(key, val);
                 }
 
+                metaData.parseAndVerify();
                 SdkType<?> sdkType = this.sdkTypeRegistry.createSdkType(metaData);
 
                 Object instance = null;

--- a/src/main/java/com/microsoft/azure/functions/worker/chain/SdkTypeMiddleware.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/chain/SdkTypeMiddleware.java
@@ -4,6 +4,7 @@ import com.microsoft.azure.functions.cache.CacheKey;
 import com.microsoft.azure.functions.internal.spi.middleware.Middleware;
 import com.microsoft.azure.functions.internal.spi.middleware.MiddlewareChain;
 import com.microsoft.azure.functions.internal.spi.middleware.MiddlewareContext;
+import com.microsoft.azure.functions.worker.binding.BindingData;
 import com.microsoft.azure.functions.worker.binding.BindingDataStore;
 import com.microsoft.azure.functions.worker.binding.ExecutionContextDataSource;
 import com.microsoft.azure.functions.worker.broker.ParamBindInfo;
@@ -59,7 +60,7 @@ public class SdkTypeMiddleware implements Middleware {
 
                 for (String key : requiredKeys) {
                     Object val = dataStore.getDataByNameFromInputSource(key, String.class, paramBindInfo.getName())
-                            .map(b -> b.getValue())
+                            .map(BindingData::getValue)
                             .orElseThrow(() -> new IllegalArgumentException("Missing " + key));
 
                     metaData.setFieldValue(key, val);

--- a/src/main/java/com/microsoft/azure/functions/worker/chain/SdkTypeMiddleware.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/chain/SdkTypeMiddleware.java
@@ -16,7 +16,9 @@ import com.microsoft.azure.functions.sdktype.SdkTypeRegistry;
 import com.microsoft.azure.functions.sdktype.SdkTypeMetaData;
 
 import java.lang.reflect.Parameter;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -50,23 +52,13 @@ public class SdkTypeMiddleware implements Middleware {
 
         try {
             ExecutionContextDataSource execCtx = (ExecutionContextDataSource) context;
-            BindingDataStore dataStore = execCtx.getDataStore();
             WorkerObjectCache<CacheKey> cache = execCtx.getCache();
 
             for (SdkTypeMetaData metaData : this.sdkTypesMetaData) {
                 Parameter param = metaData.getParam();
                 ParamBindInfo paramBindInfo = new ParamBindInfo(param);
-                Set<String> requiredKeys = metaData.getRequiredFields();
 
-                for (String key : requiredKeys) {
-                    Object val = dataStore.getDataByNameFromInputSource(key, String.class, paramBindInfo.getName())
-                            .map(BindingData::getValue)
-                            .orElseThrow(() -> new IllegalArgumentException("Missing " + key));
-
-                    metaData.setFieldValue(key, val);
-                }
-
-                metaData.parseAndVerify();
+                fillMetaData(execCtx, metaData, paramBindInfo.getName());
                 SdkType<?> sdkType = this.sdkTypeRegistry.createSdkType(metaData);
 
                 Object instance = null;
@@ -98,5 +90,44 @@ public class SdkTypeMiddleware implements Middleware {
         }
 
         chain.doNext(context);
+    }
+
+    /**
+     * Populate the {@link SdkTypeMetaData} with required field values and ensure
+     * every required key is present. Throws a single informative exception if any
+     * are missing. 
+     * 
+     * After successfully filling in all required data, a call to 
+     * SdkTypeMetaData::parseAndVerify is made using the input metaData.
+     */
+    private void fillMetaData(ExecutionContextDataSource execCtx, SdkTypeMetaData metaData, String inputSourceName) {
+
+        BindingDataStore dataStore = execCtx.getDataStore();
+        Set<String> requiredKeys = metaData.getRequiredFields();
+        List<String> missing = new ArrayList<>();
+
+        for (String key : requiredKeys) {
+            Optional<BindingData> opt = dataStore
+                    .getDataByNameFromInputSource(key, String.class, inputSourceName);
+
+            if (opt.isPresent()) {
+                metaData.setFieldValue(key, opt.get().getValue());
+            } else {
+                missing.add(key);
+            }
+        }
+
+        if (missing.isEmpty()) {
+            metaData.parseAndVerify();
+        } else {
+            throw new IllegalArgumentException(String.format(
+                    "Parameter '%s' in function '%s' (invocation %s) is missing %d required "
+                  + "key(s): %s",
+                    inputSourceName,
+                    execCtx.getFunctionName(),
+                    execCtx.getInvocationId(),
+                    missing.size(),
+                    String.join(", ", missing)));
+        }
     }
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/chain/SdkTypeMiddleware.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/chain/SdkTypeMiddleware.java
@@ -53,10 +53,12 @@ public class SdkTypeMiddleware implements Middleware {
             WorkerObjectCache<CacheKey> cache = execCtx.getCache();
 
             for (SdkTypeMetaData metaData : this.sdkTypesMetaData) {
+                Parameter param = metaData.getParam();
+                ParamBindInfo paramBindInfo = new ParamBindInfo(param);
                 Set<String> requiredKeys = metaData.getRequiredFields();
 
                 for (String key : requiredKeys) {
-                    Object val = dataStore.getDataByName(key, String.class)
+                    Object val = dataStore.getDataByNameFromInputSource(key, String.class, paramBindInfo.getName())
                             .map(b -> b.getValue())
                             .orElseThrow(() -> new IllegalArgumentException("Missing " + key));
 
@@ -84,8 +86,6 @@ public class SdkTypeMiddleware implements Middleware {
                 }
 
                 // update in data store
-                Parameter param = metaData.getParam();
-                ParamBindInfo paramBindInfo = new ParamBindInfo(param);
                 execCtx.updateParameterValue(paramBindInfo.getName(), instance);
 
                 LOGGER.info("SdkTypeMiddleware: Successfully created instance for param "


### PR DESCRIPTION
 
This pull request introduces enhancements to Azure Functions Java SDK types testing, updates dependencies, and simplifies CI pipelines. While working on adding a blob input sample I found a couple of small bugs in the SdkTypesMiddleware.

### SdkTypesMiddleware Bug Fixes
* The getDataByName call was not getting data from the correct inputsource when there are multiple input sources. I reverted the method back to its original implementation (before sdktypes support) and added a new helper that specifically looks up data in the correct input source.
* Added a missing parseAndVerify() call to the sdk type creation process. This missing call was causing the cache key to always be blank.
* I added a new emulated test to ensure that these scenarios are covered.

### Emulated Testing Enhancements:
* Introduced a new test `BlobTriggerToBlob_FromBlobInput_BlobClient_Succeeds()` in `StorageEndToEndTests.cs` to validate blob input binding functionality.

### Dependency Updates:
* Upgraded Maven plugin version to `1.38.0` in `pom.xml` to ensure compatibility with the latest features.
* Updated `azure.functions.java.sdktypes` dependency to version `1.0.1` in `pom.xml`.

### CI Pipeline Simplifications:
* Removed conditional logic for SDK types testing from `public-build.yml`, `run-emulated-tests-linux.yml`, and `run-emulated-tests-windows.yml`. This includes the elimination of `runSdkTypesTests` parameter and associated steps. [[1]](diffhunk://#diff-cb12bdcefe87ae055e2947281c7085fa2c072709d2eba96525c5e552aba7c8f3L27-L31) [[2]](diffhunk://#diff-bda3e01807ffd61592003b12ef34cd8265b418dbd808b93884135b8b81f91e76L5-L7) [[3]](diffhunk://#diff-28a39034bb284340b17656330e08b33af3cce0ee604d4d0f9d238d7315e75d68L5-L7)
* Simplified CI test configurations by removing redundant scripts and conditional SDK types testing logic. [[1]](diffhunk://#diff-bda3e01807ffd61592003b12ef34cd8265b418dbd808b93884135b8b81f91e76L87-L134) [[2]](diffhunk://#diff-28a39034bb284340b17656330e08b33af3cce0ee604d4d0f9d238d7315e75d68L89-R83)
* Added a new constant `JAVA_ENABLE_SDK_TYPES` in `Constants.java` to enable SDK types testing uniformly across environments.
* Removed local installation of dependencies since everything can now be downloaded off of maven.

### CI Pipeline Fixes:
* Fix tests for JDK 17+ on Linux
* Properly install the required JDK version using the JavaToolInstaller (we were by mistake always testing JDK 8, the built-in version)

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
