### PR TITLE
Update JDK Versions

### DIFF
--- a/eng/ci/templates/jobs/run-emulated-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-linux.yml
@@ -22,24 +22,24 @@ jobs:
       maxParallel: 4
       matrix:
         open-jdk-8-linux:
-          JDK_DOWNLOAD_LINK: 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u392b08.tar.gz'
-          JAVA_VERSION: 'OpenJDK8U-jdk_x64_linux_hotspot_8u392b08'
-          JDK_PATH: 'jdk8u392-b08'
+          JDK_DOWNLOAD_LINK: 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u442-b06/OpenJDK8U-jdk_x64_linux_hotspot_8u442b06.tar.gz'
+          JAVA_VERSION: 'OpenJDK8U-jdk_x64_linux_hotspot_8u442b06'
+          JDK_PATH: 'jdk8u442-b06'
           JAVA_VERSION_SPEC: '8'
         microsoft-open-jdk-11-linux:
-          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-11.0.21-linux-x64.tar.gz'
-          JAVA_VERSION: 'microsoft-jdk-11.0.21-linux-x64'
-          JDK_PATH: 'jdk-11.0.21+9'
+          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-11.0.26-linux-x64.tar.gz'
+          JAVA_VERSION: 'microsoft-jdk-11.0.26-linux-x64'
+          JDK_PATH: 'jdk-11.0.26+4'
           JAVA_VERSION_SPEC: '11'
         microsoft-open-jdk-17-linux:
-          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-17.0.9-linux-x64.tar.gz'
-          JAVA_VERSION: 'microsoft-jdk-17.0.9-linux-x64'
-          JDK_PATH: 'jdk-17.0.9+8'
+          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-17.0.14-linux-x64.tar.gz'
+          JAVA_VERSION: 'microsoft-jdk-17.0.14-linux-x64'
+          JDK_PATH: 'jdk-17.0.14+7'
           JAVA_VERSION_SPEC: '17'
         microsoft-open-jdk-21-linux:
-          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-21.0.1-linux-x64.tar.gz'
-          JAVA_VERSION: 'microsoft-jdk-21.0.1-linux-x64'
-          JDK_PATH: 'jdk-21.0.1+12'
+          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-21.0.6-linux-x64.tar.gz'
+          JAVA_VERSION: 'microsoft-jdk-21.0.6-linux-x64'
+          JDK_PATH: 'jdk-21.0.6+7'
           JAVA_VERSION_SPEC: '21'
 
     steps:

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -22,24 +22,24 @@ jobs:
       maxParallel: 4
       matrix:
         open-jdk-8-windows:
-          JDK_DOWNLOAD_LINK: 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u392b08.zip'
-          JAVA_VERSION: 'OpenJDK8U-jdk_x64_windows_hotspot_8u392b08'
-          JDK_PATH: 'jdk8u392-b08'
+          JDK_DOWNLOAD_LINK: 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u442-b06/OpenJDK8U-jdk_x64_windows_hotspot_8u442b06.zip'
+          JAVA_VERSION: 'OpenJDK8U-jdk_x64_windows_hotspot_8u442b06'
+          JDK_PATH: 'jdk8u442-b06'
           JAVA_VERSION_SPEC: '8'
         microsoft-open-jdk-11-windows:
-          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-11.0.21-windows-x64.zip'
-          JAVA_VERSION: 'microsoft-jdk-11.0.21-windows-x64'
-          JDK_PATH: 'jdk-11.0.21+9'
+          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-11.0.26-windows-x64.zip'
+          JAVA_VERSION: 'microsoft-jdk-11.0.26-windows-x64'
+          JDK_PATH: 'jdk-11.0.26+4'
           JAVA_VERSION_SPEC: '11'
         microsoft-open-jdk-17-windows:
-          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-17.0.9-windows-x64.zip'
-          JAVA_VERSION: 'microsoft-jdk-17.0.9-windows-x64'
-          JDK_PATH: 'jdk-17.0.9+8'
+          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-17.0.14-windows-x64.zip'
+          JAVA_VERSION: 'microsoft-jdk-17.0.14-windows-x64'
+          JDK_PATH: 'jdk-17.0.14+7'
           JAVA_VERSION_SPEC: '17'
         microsoft-open-jdk-21-windows:
-          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-21.0.1-windows-x64.zip'
-          JAVA_VERSION: 'microsoft-jdk-21.0.1-windows-x64'
-          JDK_PATH: 'jdk-21.0.1+12'
+          JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-21.0.6-windows-x64.zip'
+          JAVA_VERSION: 'microsoft-jdk-21.0.6-windows-x64'
+          JDK_PATH: 'jdk-21.0.6+7'
           JAVA_VERSION_SPEC: '21'
 
     steps:


### PR DESCRIPTION
This pull request updates the JDK versions used in the CI pipeline for both Linux and Windows environments. The changes ensure the pipeline uses the latest available versions of OpenJDK that ANT uses as default and makes availble via the RapidUpdate feed.

### Updates to JDK versions in CI pipeline:

#### Linux environment:
* Updated OpenJDK 8 to version `8u442-b06` (`run-emulated-tests-linux.yml`).
* Updated Microsoft OpenJDK 11 to version `11.0.26` (`run-emulated-tests-linux.yml`).
* Updated Microsoft OpenJDK 17 to version `17.0.14` (`run-emulated-tests-linux.yml`).
* Updated Microsoft OpenJDK 21 to version `21.0.6` (`run-emulated-tests-linux.yml`).

#### Windows environment:
* Updated OpenJDK 8 to version `8u442-b06` (`run-emulated-tests-windows.yml`).
* Updated Microsoft OpenJDK 11 to version `11.0.26` (`run-emulated-tests-windows.yml`).
* Updated Microsoft OpenJDK 17 to version `17.0.14` (`run-emulated-tests-windows.yml`).
* Updated Microsoft OpenJDK 21 to version `21.0.6` (`run-emulated-tests-windows.yml`).


### Issue describing the changes in this PR

https://github.com/Azure/azure-functions-pyfx-planning/issues/570
