### PR TITLE
add jdk 25 ea build to ci testing

### DIFF
--- a/eng/ci/templates/jobs/run-emulated-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-linux.yml
@@ -24,23 +24,23 @@ jobs:
         open-jdk-8-linux:
           JDK_DOWNLOAD_LINK: 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u442-b06/OpenJDK8U-jdk_x64_linux_hotspot_8u442b06.tar.gz'
           JAVA_VERSION: 'OpenJDK8U-jdk_x64_linux_hotspot_8u442b06'
-          JDK_PATH: 'jdk8u442-b06'
           JAVA_VERSION_SPEC: '8'
         microsoft-open-jdk-11-linux:
           JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-11.0.26-linux-x64.tar.gz'
           JAVA_VERSION: 'microsoft-jdk-11.0.26-linux-x64'
-          JDK_PATH: 'jdk-11.0.26+4'
           JAVA_VERSION_SPEC: '11'
         microsoft-open-jdk-17-linux:
           JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-17.0.14-linux-x64.tar.gz'
           JAVA_VERSION: 'microsoft-jdk-17.0.14-linux-x64'
-          JDK_PATH: 'jdk-17.0.14+7'
           JAVA_VERSION_SPEC: '17'
         microsoft-open-jdk-21-linux:
           JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-21.0.6-linux-x64.tar.gz'
           JAVA_VERSION: 'microsoft-jdk-21.0.6-linux-x64'
-          JDK_PATH: 'jdk-21.0.6+7'
           JAVA_VERSION_SPEC: '21'
+        adoptium-open-jdk-25-linux:
+          JDK_DOWNLOAD_LINK: 'https://api.adoptium.net/v3/binary/latest/25/ea/linux/x64/jdk/hotspot/normal/eclipse?project=jdk'
+          JAVA_VERSION: 'adoptium-jdk-25-ea-linux-x64'
+          JAVA_VERSION_SPEC: '25'
 
     steps:
       - task: NuGetToolInstaller@1

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -24,23 +24,23 @@ jobs:
         open-jdk-8-windows:
           JDK_DOWNLOAD_LINK: 'https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u442-b06/OpenJDK8U-jdk_x64_windows_hotspot_8u442b06.zip'
           JAVA_VERSION: 'OpenJDK8U-jdk_x64_windows_hotspot_8u442b06'
-          JDK_PATH: 'jdk8u442-b06'
           JAVA_VERSION_SPEC: '8'
         microsoft-open-jdk-11-windows:
           JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-11.0.26-windows-x64.zip'
           JAVA_VERSION: 'microsoft-jdk-11.0.26-windows-x64'
-          JDK_PATH: 'jdk-11.0.26+4'
           JAVA_VERSION_SPEC: '11'
         microsoft-open-jdk-17-windows:
           JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-17.0.14-windows-x64.zip'
           JAVA_VERSION: 'microsoft-jdk-17.0.14-windows-x64'
-          JDK_PATH: 'jdk-17.0.14+7'
           JAVA_VERSION_SPEC: '17'
         microsoft-open-jdk-21-windows:
           JDK_DOWNLOAD_LINK: 'https://aka.ms/download-jdk/microsoft-jdk-21.0.6-windows-x64.zip'
           JAVA_VERSION: 'microsoft-jdk-21.0.6-windows-x64'
-          JDK_PATH: 'jdk-21.0.6+7'
           JAVA_VERSION_SPEC: '21'
+        adoptium-open-jdk-25-windows:
+          JDK_DOWNLOAD_LINK: 'https://api.adoptium.net/v3/binary/latest/25/ea/windows/x64/jdk/hotspot/normal/eclipse?project=jdk'
+          JAVA_VERSION: 'adoptium-jdk-25-ea-windows-x64'
+          JAVA_VERSION_SPEC: '25'
 
     steps:
       - task: NuGetToolInstaller@1


### PR DESCRIPTION
This pull request updates the configuration for running emulated tests on both Linux and Windows environments. It removes the `JDK_PATH` property for existing JDKs and adds support for the latest Adoptium OpenJDK 25.

### Updates to JDK configurations:
- **Linux environment:** Removed the `JDK_PATH` property for OpenJDK 8, Microsoft OpenJDK 11, 17, and 21, and added support for Adoptium OpenJDK 25 with its download link and version specifications. (`eng/ci/templates/jobs/run-emulated-tests-linux.yml`, [eng/ci/templates/jobs/run-emulated-tests-linux.ymlL27-R43](diffhunk://#diff-bda3e01807ffd61592003b12ef34cd8265b418dbd808b93884135b8b81f91e76L27-R43))
- **Windows environment:** Removed the `JDK_PATH` property for OpenJDK 8, Microsoft OpenJDK 11, 17, and 21, and added support for Adoptium OpenJDK 25 with its download link and version specifications. (`eng/ci/templates/jobs/run-emulated-tests-windows.yml`, [eng/ci/templates/jobs/run-emulated-tests-windows.ymlL27-R43](diffhunk://#diff-28a39034bb284340b17656330e08b33af3cce0ee604d4d0f9d238d7315e75d68L27-R43))