### PR TITLE
Update sdktypes to 1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <azure.functions.java.core.library.version>1.3.0</azure.functions.java.core.library.version>
     <azure.functions.java.spi>1.1.0</azure.functions.java.spi>
-    <azure.functions.java.sdktypes>1.0.1</azure.functions.java.sdktypes>
+    <azure.functions.java.sdktypes>1.0.2</azure.functions.java.sdktypes>
     <azure.functions.java.library.version>2.2.0</azure.functions.java.library.version>
     <jupiter.version>5.9.1</jupiter.version>
     <mockito-core.version>4.11.0</mockito-core.version>


### PR DESCRIPTION
This pull request includes a minor update to the project dependencies in `pom.xml`. The version of the `azure.functions.java.sdktypes` dependency has been bumped from `1.0.1` to `1.0.2` to ensure the project uses the latest features and bug fixes.