### PR TITLE
Fix functionInstanceInjector null on concurrent cold start (#879)

### DIFF
--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
@@ -115,8 +115,12 @@ public class JavaFunctionBroker {
 						initializeInvocationChainFactory();
 					}
 
-					oneTimeLogicInitialized = true;
+					// Initialize the injector before flipping the flag. The outer check on
+					// oneTimeLogicInitialized is lock-free, so a concurrent load thread that sees the
+					// flag set will skip init and can invoke while functionInstanceInjector is still
+					// null. See issue #879.
 					initializeFunctionInstanceInjector();
+					oneTimeLogicInitialized = true;
 				}
 			}
 		}

--- a/src/test/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBrokerConcurrentInitTest.java
+++ b/src/test/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBrokerConcurrentInitTest.java
@@ -1,0 +1,83 @@
+package com.microsoft.azure.functions.worker.broker;
+
+import com.microsoft.azure.functions.worker.reflect.ClassLoaderProvider;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression guard for issue #879.
+ *
+ * initializeOneTimeLogics() runs the double-checked locking pattern behind a volatile flag. The
+ * injector must be built before that flag flips to true. If the flag is set first, a second load
+ * thread can pass the lock-free outer check, skip initialization, and start invoking while
+ * functionInstanceInjector is still null, which throws NPE in
+ * ExecutionContextDataSource.getFunctionInstance().
+ */
+public class JavaFunctionBrokerConcurrentInitTest {
+
+    @Test
+    public void flagIsNotSetUntilInjectorIsInitialized() throws Exception {
+        CountDownLatch reachedInjectorInit = new CountDownLatch(1);
+        CountDownLatch releaseInjectorInit = new CountDownLatch(1);
+        AtomicInteger createClassLoaderCalls = new AtomicInteger();
+
+        // createClassLoader() is called once at the top of initializeOneTimeLogics() and once inside
+        // initializeFunctionInstanceInjector(). Freeze the second call so the broker can be observed
+        // at the exact point the injector is about to be built.
+        ClassLoaderProvider classLoaderProvider = mock(ClassLoaderProvider.class);
+        when(classLoaderProvider.createClassLoader()).thenAnswer(invocation -> {
+            if (createClassLoaderCalls.incrementAndGet() == 2) {
+                reachedInjectorInit.countDown();
+                releaseInjectorInit.await(10, TimeUnit.SECONDS);
+            }
+            return Thread.currentThread().getContextClassLoader();
+        });
+
+        JavaFunctionBroker broker = new JavaFunctionBroker(classLoaderProvider);
+
+        Method initializeOneTimeLogics = JavaFunctionBroker.class.getDeclaredMethod("initializeOneTimeLogics");
+        initializeOneTimeLogics.setAccessible(true);
+        Field oneTimeLogicInitialized = JavaFunctionBroker.class.getDeclaredField("oneTimeLogicInitialized");
+        oneTimeLogicInitialized.setAccessible(true);
+        Field functionInstanceInjector = JavaFunctionBroker.class.getDeclaredField("functionInstanceInjector");
+        functionInstanceInjector.setAccessible(true);
+
+        AtomicReference<Throwable> initFailure = new AtomicReference<>();
+        Thread initThread = new Thread(() -> {
+            try {
+                initializeOneTimeLogics.invoke(broker);
+            } catch (Throwable t) {
+                initFailure.set(t);
+            }
+        }, "one-time-init");
+        initThread.setDaemon(true);
+        initThread.start();
+
+        assertTrue(reachedInjectorInit.await(5, TimeUnit.SECONDS), "init thread never reached injector initialization");
+
+        // The injector has not been built yet, so the flag must still be false. If it is already
+        // true here, a concurrent thread would see an "initialized" broker with a null injector.
+        assertNull(functionInstanceInjector.get(broker), "test precondition: injector should not be built yet");
+        assertFalse((boolean) oneTimeLogicInitialized.get(broker),
+                "oneTimeLogicInitialized was set before the injector was initialized (issue #879 regression)");
+
+        releaseInjectorInit.countDown();
+        initThread.join(TimeUnit.SECONDS.toMillis(5));
+
+        assertNull(initFailure.get(), () -> "initializeOneTimeLogics threw: " + initFailure.get());
+        assertFalse(initThread.isAlive(), "init thread did not finish");
+        assertTrue((boolean) oneTimeLogicInitialized.get(broker), "flag should be set once initialization completes");
+        assertNotNull(functionInstanceInjector.get(broker), "injector should be initialized once init completes");
+        assertEquals(2, createClassLoaderCalls.get(), "createClassLoader hook did not match the injector init call");
+    }
+}


### PR DESCRIPTION
## What this fixes

Fixes #879. Since worker 2.19.2, an instance can start up with `functionInstanceInjector` left null for its whole lifetime, and then every invocation on that instance fails with an NPE.

```
java.lang.NullPointerException: Cannot invoke
  "com.microsoft.azure.functions.spi.inject.FunctionInstanceInjector.getInstance(java.lang.Class)"
  because "this.functionInstanceInjector" is null
    at com.microsoft.azure.functions.worker.binding.ExecutionContextDataSource.getFunctionInstance(ExecutionContextDataSource.java:108)
```

## Root cause

`JavaFunctionBroker.initializeOneTimeLogics()` uses double-checked locking behind the volatile `oneTimeLogicInitialized` flag. Since 2.19.2 it set the flag to true before building the injector.

```java
oneTimeLogicInitialized = true;          // flag set first
initializeFunctionInstanceInjector();    // slow ServiceLoader scan runs after
```

Function load requests are dispatched concurrently, since `JavaWorkerClient` submits every message to a cached thread pool. At cold start two threads run `loadMethod` at the same time. Thread A enters the locked block and sets the flag. Thread B hits the lock-free outer check, sees the flag already true, returns early, and starts invoking while the injector is still null. The `ServiceLoader` scan for a custom injector (for example the Spring Cloud Function adapter) widens the window.

This is the same NPE that #684 fixed. #819 (OpenTelemetry support) reordered the two lines and reopened it.

## The fix

Build the injector before flipping the flag, which restores the #684 ordering.

```java
initializeFunctionInstanceInjector();
oneTimeLogicInitialized = true;
```

## Test

Adds `JavaFunctionBrokerConcurrentInitTest`, which freezes a thread at the point the injector is about to be built and asserts `oneTimeLogicInitialized` is still false there. It fails on the old ordering and passes with the fix.

## Affected versions

Regressed in 2.19.2 and present through 2.19.4. 2.19.1 and earlier are fine.
