### PR TITLE
Update Java Worker Version to 2.19.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.azure.functions</groupId>
   <artifactId>azure-functions-java-worker</artifactId>
-  <version>2.19.4</version>
+  <version>2.19.5</version>
   <packaging>jar</packaging>
   <name>Azure Functions Java Worker</name>
   <description>This package contains the Java Language Worker used by Azure functions host to execute java functions</description>


### PR DESCRIPTION
Bumps the worker version on dev to 2.19.5 to match the release/2.19.5 branch.