### PR TITLE
Onboard Java worker dependency restores to CFS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,11 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure-rest:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@colors:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@dabh:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@js-joda:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@microsoft:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@opentelemetry:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@so-ric:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@types:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@typespec:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="upstream-public">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/eng/ci/templates/jobs/run-docker-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-docker-tests-linux.yml
@@ -57,6 +57,12 @@ jobs:
           versionSpec: '3.11'
           addToPath: true
 
+      - task: PipAuthenticate@1
+        displayName: 'Authenticate pip to CFS'
+        inputs:
+          artifactFeeds: 'public/upstream-public'
+          onlyAddExtraIndex: false
+
       - bash: |
           python -m pip install --upgrade pip
           pip install -e dockertests/azure-functions-test-kit

--- a/eng/ci/templates/jobs/run-emulated-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-linux.yml
@@ -92,11 +92,17 @@ jobs:
           jdkDestinationDirectory: "$(downloadPath)/externals"
           cleanDestinationDirectory: true
         displayName: 'Setup Java for Linux'
+      - task: npmAuthenticate@0
+        inputs:
+          workingFile: '$(Build.SourcesDirectory)/.npmrc'
+        displayName: 'Authenticate npm to CFS'
       - bash: |
           npm install -g azurite
           mkdir azurite
           azurite --skipApiVersionCheck --silent --location azurite --debug azurite/debug.log &
         displayName: 'Install and Run Azurite'
+        env:
+          NPM_CONFIG_USERCONFIG: '$(Build.SourcesDirectory)/.npmrc'
       - pwsh: |
           if ("$(isTag)"){
             $buildNumber="$(Build.SourceBranchName)"
@@ -116,15 +122,23 @@ jobs:
           mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
           Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-emulatedtests"
         displayName: 'Download CA Bundle & Package Java for Emulated Tests'
+      - task: npmAuthenticate@0
+        inputs:
+          workingFile: '$(Build.SourcesDirectory)/.npmrc'
+        displayName: 'Authenticate npm to CFS'
       - pwsh: |
           .\setup-tests-pipeline.ps1
         displayName: 'Setup test environment -- Install the Core Tools'
+        env:
+          NPM_CONFIG_USERCONFIG: '$(Build.SourcesDirectory)/.npmrc'
       - bash: |
           chmod +x ./Azure.Functions.Cli/func
           chmod +x ./Azure.Functions.Cli/gozip
           export PATH=$PATH:./Azure.Functions.Cli
           func --version
         displayName: 'Setup Core Tools - Linux'
+      - task: NuGetAuthenticate@1
+        displayName: 'Authenticate NuGet to CFS'
       - task: DotNetCoreCLI@2
         retryCountOnTaskFailure: 3
         inputs:

--- a/eng/ci/templates/jobs/run-emulated-tests-windows.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-windows.yml
@@ -73,11 +73,17 @@ jobs:
           jdkDestinationDirectory: "$(downloadPath)/externals"
           cleanDestinationDirectory: true
         displayName: 'Setup Java for Windows'
+      - task: npmAuthenticate@0
+        inputs:
+          workingFile: '$(Build.SourcesDirectory)/.npmrc'
+        displayName: 'Authenticate npm to CFS'
       - bash: |
           npm install -g azurite
           mkdir azurite
           azurite --skipApiVersionCheck --silent --location azurite --debug azurite\debug.log &
         displayName: 'Install and Run Azurite'
+        env:
+          NPM_CONFIG_USERCONFIG: '$(Build.SourcesDirectory)/.npmrc'
       - pwsh: |
           if ("$(isTag)"){
             $buildNumber="$(Build.SourceBranchName)"
@@ -97,14 +103,22 @@ jobs:
           mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
           Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-emulatedtests"
         displayName: 'Download CA Bundle & Package Java for Emulated Tests'
+      - task: npmAuthenticate@0
+        inputs:
+          workingFile: '$(Build.SourcesDirectory)/.npmrc'
+        displayName: 'Authenticate npm to CFS'
       - pwsh: |
           .\setup-tests-pipeline.ps1
         displayName: 'Setup test environment -- Install the Core Tools'
+        env:
+          NPM_CONFIG_USERCONFIG: '$(Build.SourcesDirectory)/.npmrc'
       - pwsh: |
           $currDir =  Get-Location
           $Env:Path = $Env:Path+";$currDir/Azure.Functions.Cli"
           func --version
         displayName: 'Setup Core Tools - Windows'
+      - task: NuGetAuthenticate@1
+        displayName: 'Authenticate NuGet to CFS'
       - task: DotNetCoreCLI@2
         retryCountOnTaskFailure: 3
         inputs:

--- a/eng/ci/templates/official/jobs/run-e2e-tests-linux.yml
+++ b/eng/ci/templates/official/jobs/run-e2e-tests-linux.yml
@@ -84,9 +84,15 @@ jobs:
           jdkDestinationDirectory: "$(downloadPath)/externals"
           cleanDestinationDirectory: true
         displayName: 'Setup Java for Linux'
+      - task: npmAuthenticate@0
+        inputs:
+          workingFile: '$(Build.SourcesDirectory)/.npmrc'
+        displayName: 'Authenticate npm to CFS'
       - pwsh: |
           .\setup-tests-pipeline.ps1
         displayName: 'Setup test environment -- Install the Core Tools'
+        env:
+          NPM_CONFIG_USERCONFIG: '$(Build.SourcesDirectory)/.npmrc'
       - bash: |
           chmod +x ./Azure.Functions.Cli/func
           chmod +x ./Azure.Functions.Cli/gozip
@@ -100,6 +106,8 @@ jobs:
           mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
           Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-endtoendtests"
         displayName: 'Download CA Bundle & Package Java for E2E'
+      - task: NuGetAuthenticate@1
+        displayName: 'Authenticate NuGet to CFS'
       - task: DotNetCoreCLI@2
         retryCountOnTaskFailure: 3
         inputs:

--- a/eng/ci/templates/official/jobs/run-e2e-tests-windows.yml
+++ b/eng/ci/templates/official/jobs/run-e2e-tests-windows.yml
@@ -69,9 +69,15 @@ jobs:
           Write-Host "##vso[task.setvariable variable=JavaHome;]$current"
         displayName: 'Download and setup Java for Windows'
 
+      - task: npmAuthenticate@0
+        inputs:
+          workingFile: '$(Build.SourcesDirectory)/.npmrc'
+        displayName: 'Authenticate npm to CFS'
       - pwsh: |
           .\setup-tests-pipeline.ps1
         displayName: 'Setup test environment -- Install the Core Tools'
+        env:
+          NPM_CONFIG_USERCONFIG: '$(Build.SourcesDirectory)/.npmrc'
 
       - pwsh: |
           $currDir =  Get-Location
@@ -85,6 +91,8 @@ jobs:
           mvn clean package `-Dmaven`.javadoc`.skip=true `-Dmaven`.test`.skip `-Dorg`.slf4j`.simpleLogger`.log`.org`.apache`.maven`.cli`.transfer`.Slf4jMavenTransferListener=warn `-B
           Copy-Item "confluent_cloud_cacert.pem" "./target/azure-functions/azure-functions-java-endtoendtests"
         displayName: 'Download CA Bundle & Package Java for E2E'
+      - task: NuGetAuthenticate@1
+        displayName: 'Authenticate NuGet to CFS'
       - task: DotNetCoreCLI@2
         retryCountOnTaskFailure: 3
         inputs:

--- a/setup-tests-pipeline.ps1
+++ b/setup-tests-pipeline.ps1
@@ -11,6 +11,12 @@ $FUNC_RUNTIME_VERSION = 'latest'
 
 Write-Host "Installing Core Tools globlally using npm, version: $FUNC_RUNTIME_VERSION ..."
 
+$env:NPM_CONFIG_USERCONFIG = if ($env:NPM_CONFIG_USERCONFIG) {
+    $env:NPM_CONFIG_USERCONFIG
+} else {
+    Join-Path $PSScriptRoot '.npmrc'
+}
+
 $FUNC_CLI_DIRECTORY = Join-Path $PSScriptRoot 'Azure.Functions.Cli'
 $InstallDir         = $FUNC_CLI_DIRECTORY
 


### PR DESCRIPTION
## Summary
- route global npm dependency resolution through the public CFS registry, including every scope in the resolved Azurite and Core Tools graph
- route .NET test restores through a source-mapped CFS-only NuGet configuration
- authenticate npm, NuGet, and pip dependency paths in Azure Pipelines and carry `NPM_CONFIG_USERCONFIG` through global installs

## Validation
- resolved Azurite and Azure Functions Core Tools from an empty npm cache; all 309 lockfile package URLs used CFS
- restored both .NET test projects from separate empty global package caches; CFS was the only remote NuGet source
- verified npm user-config handling with a path containing spaces, NuGet XML parsing, PowerShell parsing, and diff whitespace

## Caveat
Maven remains unchanged. The repository uses Maven Central implicitly and declares Sonatype snapshot repositories in the worker and E2E test POMs, but the supplied CFS guidance does not define Maven migration mechanics. Customer-facing samples and documentation are intentionally preserved.