### PR TITLE
Add OpenTelemetry baggage propagation

### DIFF
--- a/src/main/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+++ b/src/main/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
@@ -392,6 +392,9 @@ message RpcTraceContext {
 
   // This corresponds to Activity.Current?.Tags
   map<string, string> attributes = 3;
+
+  // This is populated from OpenTelemetry.Baggage.Current
+  map<string, string> baggage = 4;
 }
 
 // Host sends retry context for a function invocation

--- a/src/main/java/com/microsoft/azure/functions/worker/binding/ExecutionTraceContext.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/binding/ExecutionTraceContext.java
@@ -5,8 +5,10 @@ import java.util.Map;
 import com.microsoft.azure.functions.TraceContext;
 
 final public class ExecutionTraceContext implements TraceContext {
-    public ExecutionTraceContext(String traceParent, String traceState,  Map<String, String> attributes) {
+    public ExecutionTraceContext(String traceParent, String traceState, Map<String, String> attributes,
+                                 Map<String, String> baggage) {
         this.Attributes = attributes;
+        this.Baggage = baggage;
         this.Traceparent = traceParent;
         this.Tracestate = traceState;
     }
@@ -20,7 +22,10 @@ final public class ExecutionTraceContext implements TraceContext {
     @Override
     public Map<String, String> getAttributes() { return this.Attributes; }
 
+    public Map<String, String> getBaggage() { return this.Baggage; }
+
     private final String Traceparent;
     private final String Tracestate;
     private final Map<String, String> Attributes;
+    private final Map<String, String> Baggage;
 }

--- a/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
+++ b/src/main/java/com/microsoft/azure/functions/worker/broker/JavaFunctionBroker.java
@@ -213,7 +213,8 @@ public class JavaFunctionBroker {
 		dataStore.addTriggerMetadataSource(getTriggerMetadataMap(request));
 		dataStore.addParameterSources(request.getInputDataList());
 		ExecutionTraceContext traceContext = new ExecutionTraceContext(request.getTraceContext().getTraceParent(),
-				request.getTraceContext().getTraceState(), request.getTraceContext().getAttributesMap());
+				request.getTraceContext().getTraceState(), request.getTraceContext().getAttributesMap(),
+				request.getTraceContext().getBaggageMap());
 		ExecutionRetryContext retryContext = new ExecutionRetryContext(request.getRetryContext().getRetryCount(),
 				request.getRetryContext().getMaxRetryCount(), request.getRetryContext().getException());
 		ExecutionContextDataSource executionContextDataSource = new ExecutionContextDataSource(

--- a/src/test/java/com/microsoft/azure/functions/worker/broker/ParameterResolverTest.java
+++ b/src/test/java/com/microsoft/azure/functions/worker/broker/ParameterResolverTest.java
@@ -35,7 +35,8 @@ public class ParameterResolverTest {
     @BeforeEach
     public void setup() {
         String invocationId = "testInvocationId";
-        ExecutionTraceContext traceContext = new ExecutionTraceContext("traceParent", "traceState", new HashMap<>());
+        ExecutionTraceContext traceContext = new ExecutionTraceContext("traceParent", "traceState", new HashMap<>(),
+                new HashMap<>());
         ExecutionRetryContext retryContext = new ExecutionRetryContext(1, 2, RpcException.newBuilder().build());
         String functionName = "ParameterResolverTest";
         BindingDataStore dataStore = new BindingDataStore();

--- a/src/test/java/com/microsoft/azure/functions/worker/test/ExecutionTraceContextTest.java
+++ b/src/test/java/com/microsoft/azure/functions/worker/test/ExecutionTraceContextTest.java
@@ -15,15 +15,19 @@ public class ExecutionTraceContextTest {
         String traceParent = "randomTraceParent";
         String traceState = "randomTraceState";
         HashMap<String, String> attributes = new HashMap<String, String>();
+        HashMap<String, String> baggage = new HashMap<String, String>();
 
         attributes.put("key1", "value1");
         attributes.put("key2", "value2");
+        baggage.put("baggageKey1", "baggageValue1");
+        baggage.put("baggageKey2", "baggageValue2");
 
-        TraceContext testTraceContext = new ExecutionTraceContext(traceParent, traceState, attributes);
+        ExecutionTraceContext testTraceContext = new ExecutionTraceContext(traceParent, traceState, attributes, baggage);
         assertEquals(traceParent, testTraceContext.getTraceparent());
         assertEquals(traceState, testTraceContext.getTracestate());
         assertEquals(traceState, testTraceContext.getTracestate());
         assertEquals(attributes, testTraceContext.getAttributes());
+        assertEquals(baggage, testTraceContext.getBaggage());
     }
 
     @Test
@@ -31,19 +35,22 @@ public class ExecutionTraceContextTest {
         String traceParent = "";
         String traceState = "";
         HashMap<String, String> attributes = new HashMap<String, String>();
-        TraceContext testTraceContext = new ExecutionTraceContext(traceParent, traceState, attributes);
+        HashMap<String, String> baggage = new HashMap<String, String>();
+        ExecutionTraceContext testTraceContext = new ExecutionTraceContext(traceParent, traceState, attributes, baggage);
         assertEquals(traceParent, testTraceContext.getTraceparent());
         assertEquals(traceState, testTraceContext.getTracestate());
         assertEquals(traceState, testTraceContext.getTracestate());
         assertEquals(attributes, testTraceContext.getAttributes());
+        assertEquals(baggage, testTraceContext.getBaggage());
     }
 
     @Test
     public void TraceContext_test_getAndset_Null() {
-        TraceContext testTraceContext = new ExecutionTraceContext(null, null, null);
+        ExecutionTraceContext testTraceContext = new ExecutionTraceContext(null, null, null, null);
         assertEquals(null, testTraceContext.getTraceparent());
         assertEquals(null, testTraceContext.getTracestate());
         assertEquals(null, testTraceContext.getTracestate());
         assertEquals(null, testTraceContext.getAttributes());
+        assertEquals(null, testTraceContext.getBaggage());
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resolves #866

This PR adds worker-side support for OpenTelemetry Baggage propagation by:

- Adding the `baggage` map from language worker protobuf v1.13.0 to `RpcTraceContext`.
- Passing baggage received from the Functions host into `ExecutionTraceContext`.
- Exposing the baggage values through `ExecutionTraceContext#getBaggage()`.
- Adding unit coverage for non-empty, empty, and null baggage values.

### Pull request checklist

* [x] My changes **do not** require documentation changes
  * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
  * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
  * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

The public `TraceContext` interface in `azure-functions-java-core-library` does not currently expose a baggage accessor. A coordinated core-library update is required to add `getBaggage()` to the customer-facing API. Once that version is released, the worker dependency can be updated and `ExecutionTraceContext#getBaggage()` can explicitly override the interface method.