### PR TITLE
[experiment] ci: try 1es-ubuntu-24.04-min for Linux jobs instead of disk cleanup

### DIFF
--- a/eng/ci/templates/jobs/run-docker-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-docker-tests-linux.yml
@@ -9,7 +9,7 @@ jobs:
 
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
 
     strategy:
@@ -37,15 +37,11 @@ jobs:
         inputs:
           artifactsFeeds: upstream-public
       - bash: |
-          echo "=== disk BEFORE cleanup ==="
+          echo "=== disk space (no cleanup: measuring 1es-ubuntu-24.04-min baseline) ==="
           df -h /
-          echo "=== freeing space (toolsets this job does not use) ==="
-          sudo rm -rf /usr/local/lib/android /opt/ghc /usr/local/.ghcup /usr/share/swift \
-                      /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/PyPy 2>/dev/null || true
-          sudo apt-get clean || true
-          echo "=== disk AFTER cleanup ==="
-          df -h /
-        displayName: 'Free up disk space'
+          echo "=== top consumers on / ==="
+          sudo du -xh --max-depth=2 / 2>/dev/null | sort -rh | head -20 || true
+        displayName: 'Report disk space'
 
       - bash: |
           mvn --version

--- a/eng/ci/templates/jobs/run-docker-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-docker-tests-linux.yml
@@ -37,11 +37,21 @@ jobs:
         inputs:
           artifactsFeeds: upstream-public
       - bash: |
-          echo "=== disk space (no cleanup: measuring 1es-ubuntu-24.04-min baseline) ==="
+          set +e
+          echo "=== disk ==="
           df -h /
-          echo "=== top consumers on / ==="
-          sudo du -xh --max-depth=2 / 2>/dev/null | sort -rh | head -20 || true
-        displayName: 'Report disk space'
+          echo "=== toolchain ==="
+          for t in mvn java javac docker python3 node npm dotnet; do
+            printf '%-10s %s\n' "$t" "$(command -v $t 2>/dev/null || echo MISSING)"
+          done
+          echo "=== /opt/hostedtoolcache ==="
+          ls -1 /opt/hostedtoolcache 2>/dev/null || echo "(absent)"
+          echo "=== JDKs (/usr/lib/jvm) ==="
+          ls -1 /usr/lib/jvm 2>/dev/null || echo "(none)"
+          echo "=== docker daemon ==="
+          docker info >/dev/null 2>&1 && echo "available" || echo "NOT available"
+          exit 0
+        displayName: 'Probe: disk + toolchain'
 
       - bash: |
           mvn --version

--- a/eng/ci/templates/jobs/run-docker-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-docker-tests-linux.yml
@@ -9,7 +9,7 @@ jobs:
 
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-24.04-min
+      image: 1es-ubuntu-24.04
       os: linux
 
     strategy:

--- a/eng/ci/templates/jobs/run-docker-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-docker-tests-linux.yml
@@ -9,7 +9,7 @@ jobs:
 
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-24.04
+      image: 1es-ubuntu-22.04
       os: linux
 
     strategy:
@@ -37,21 +37,15 @@ jobs:
         inputs:
           artifactsFeeds: upstream-public
       - bash: |
-          set +e
-          echo "=== disk ==="
+          echo "=== disk BEFORE cleanup ==="
           df -h /
-          echo "=== toolchain ==="
-          for t in mvn java javac docker python3 node npm dotnet; do
-            printf '%-10s %s\n' "$t" "$(command -v $t 2>/dev/null || echo MISSING)"
-          done
-          echo "=== /opt/hostedtoolcache ==="
-          ls -1 /opt/hostedtoolcache 2>/dev/null || echo "(absent)"
-          echo "=== JDKs (/usr/lib/jvm) ==="
-          ls -1 /usr/lib/jvm 2>/dev/null || echo "(none)"
-          echo "=== docker daemon ==="
-          docker info >/dev/null 2>&1 && echo "available" || echo "NOT available"
-          exit 0
-        displayName: 'Probe: disk + toolchain'
+          echo "=== freeing space (toolsets this job does not use) ==="
+          sudo rm -rf /usr/local/lib/android /opt/ghc /usr/local/.ghcup /usr/share/swift \
+                      /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/PyPy 2>/dev/null || true
+          sudo apt-get clean || true
+          echo "=== disk AFTER cleanup ==="
+          df -h /
+        displayName: 'Free up disk space'
 
       - bash: |
           mvn --version

--- a/eng/ci/templates/jobs/run-emulated-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-linux.yml
@@ -69,10 +69,6 @@ jobs:
       - bash: |
           df -h /
         displayName: 'Report disk space'
-      - task: NuGetToolInstaller@1
-        inputs:
-          checkLatest: true
-        displayName: 'Install NuGet Tool'
       - pwsh: |
           Get-Command mvn
         displayName: 'Check Maven is installed'
@@ -118,7 +114,9 @@ jobs:
             Write-Host "git tag not found. Setting package suffix to '$buildNumber'"
           }
           Write-Host "##vso[task.setvariable variable=buildNumber;isOutput=true;]$buildNumber"
-          .\package-pipeline.ps1 -buildNumber $buildNumber
+          # -skipNuget: these tests consume the worker from target/, never the .nupkg, and the
+          # nuget CLI needs mono, which the -min image does not ship.
+          .\package-pipeline.ps1 -buildNumber $buildNumber -skipNuget
         displayName: 'Executing build script'
       - pwsh: |
           ./eng/scripts/Export-JavaCacerts.ps1 -OutputPath "./emulatedtests/confluent_cloud_cacert.pem"

--- a/eng/ci/templates/jobs/run-emulated-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-linux.yml
@@ -57,11 +57,21 @@ jobs:
         inputs:
           artifactsFeeds: upstream-public
       - bash: |
-          echo "=== disk space (no cleanup: measuring 1es-ubuntu-24.04-min baseline) ==="
+          set +e
+          echo "=== disk ==="
           df -h /
-          echo "=== top consumers on / ==="
-          sudo du -xh --max-depth=2 / 2>/dev/null | sort -rh | head -20 || true
-        displayName: 'Report disk space'
+          echo "=== toolchain ==="
+          for t in mvn java javac docker python3 node npm dotnet; do
+            printf '%-10s %s\n' "$t" "$(command -v $t 2>/dev/null || echo MISSING)"
+          done
+          echo "=== /opt/hostedtoolcache ==="
+          ls -1 /opt/hostedtoolcache 2>/dev/null || echo "(absent)"
+          echo "=== JDKs (/usr/lib/jvm) ==="
+          ls -1 /usr/lib/jvm 2>/dev/null || echo "(none)"
+          echo "=== docker daemon ==="
+          docker info >/dev/null 2>&1 && echo "available" || echo "NOT available"
+          exit 0
+        displayName: 'Probe: disk + toolchain'
       - task: NuGetToolInstaller@1
         inputs:
           checkLatest: true

--- a/eng/ci/templates/jobs/run-emulated-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-linux.yml
@@ -9,7 +9,7 @@ jobs:
 
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-24.04
+      image: 1es-ubuntu-24.04-min
       os: linux
 
     variables:
@@ -45,6 +45,16 @@ jobs:
           JAVA_VERSION_SPEC: '25'
 
     steps:
+      # The -min image ships no Maven and no Node, so install them up front.
+      - bash: |
+          set -e
+          sudo apt-get update
+          sudo apt-get install -y maven
+        displayName: 'Install Maven'
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '20.x'
+        displayName: 'Install Node.js'
       # Maven resolves plugins and extensions before a pom's repositories are honored. Install the
       # mirror before MavenAuthenticate@0, which adds credentials to the same settings file.
       - pwsh: |
@@ -57,21 +67,8 @@ jobs:
         inputs:
           artifactsFeeds: upstream-public
       - bash: |
-          set +e
-          echo "=== disk ==="
           df -h /
-          echo "=== toolchain ==="
-          for t in mvn java javac docker python3 node npm dotnet; do
-            printf '%-10s %s\n' "$t" "$(command -v $t 2>/dev/null || echo MISSING)"
-          done
-          echo "=== /opt/hostedtoolcache ==="
-          ls -1 /opt/hostedtoolcache 2>/dev/null || echo "(absent)"
-          echo "=== JDKs (/usr/lib/jvm) ==="
-          ls -1 /usr/lib/jvm 2>/dev/null || echo "(none)"
-          echo "=== docker daemon ==="
-          docker info >/dev/null 2>&1 && echo "available" || echo "NOT available"
-          exit 0
-        displayName: 'Probe: disk + toolchain'
+        displayName: 'Report disk space'
       - task: NuGetToolInstaller@1
         inputs:
           checkLatest: true
@@ -79,12 +76,6 @@ jobs:
       - pwsh: |
           Get-Command mvn
         displayName: 'Check Maven is installed'
-      - task: JavaToolInstaller@0 # This step is necessary as Linux image has Java 11 as default
-        inputs:
-          versionSpec: '8'
-          jdkArchitectureOption: 'x64'
-          jdkSourceOption: 'PreInstalled'
-        displayName: 'Setup Java for Linux'
       - pwsh: |
           java -version
         displayName: 'Check default java version'

--- a/eng/ci/templates/jobs/run-emulated-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-linux.yml
@@ -9,7 +9,7 @@ jobs:
 
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-22.04
+      image: 1es-ubuntu-24.04-min
       os: linux
 
     variables:
@@ -57,18 +57,11 @@ jobs:
         inputs:
           artifactsFeeds: upstream-public
       - bash: |
-          echo "=== disk BEFORE cleanup ==="
+          echo "=== disk space (no cleanup: measuring 1es-ubuntu-24.04-min baseline) ==="
           df -h /
-          echo "=== top consumers on / (baseline) ==="
+          echo "=== top consumers on / ==="
           sudo du -xh --max-depth=2 / 2>/dev/null | sort -rh | head -20 || true
-          echo "=== freeing space (toolsets this job does not use) ==="
-          sudo rm -rf /usr/local/lib/android /opt/ghc /usr/local/.ghcup /usr/share/swift \
-                      /opt/hostedtoolcache/CodeQL /opt/hostedtoolcache/PyPy 2>/dev/null || true
-          docker image prune -af || true
-          sudo apt-get clean || true
-          echo "=== disk AFTER cleanup ==="
-          df -h /
-        displayName: 'Free up disk space'
+        displayName: 'Report disk space'
       - task: NuGetToolInstaller@1
         inputs:
           checkLatest: true

--- a/eng/ci/templates/jobs/run-emulated-tests-linux.yml
+++ b/eng/ci/templates/jobs/run-emulated-tests-linux.yml
@@ -9,7 +9,7 @@ jobs:
 
     pool:
       name: ${{ parameters.poolName }}
-      image: 1es-ubuntu-24.04-min
+      image: 1es-ubuntu-24.04
       os: linux
 
     variables:


### PR DESCRIPTION
**Experiment — not for merge as-is.** Opened as a draft to get a CI signal.

## What
Switch the two Linux CI jobs (emulated tests, docker integration tests) from `1es-ubuntu-22.04` to `1es-ubuntu-24.04-min`, and drop the `Free up disk space` cleanup steps that #883 added. A `df`/`du` report step is kept so the run tells us the new image's baseline headroom.

## Why
The `1es-ubuntu-22.04` image boots ~92% full on `/` (67G used of 73G), almost entirely from toolsets these jobs never touch — Android SDK and Haskell under `/usr/local` (~24G), pre-cached docker images (~12G), Swift/miniconda under `/usr/share` (~9.5G), CodeQL/PyPy in the tool cache (~6.7G). That left so little headroom that `dotnet test` filled the disk, the agent process aborted with exit 134, and ADO reported the job as **canceled**.

#883 worked around it by `rm -rf`-ing those toolsets at job start (`/` 92% → 54%, ~28G freed), which has held: 17 of 18 nightly `dev` builds since have passed with zero cancellations.

That workaround is still deleting things out from under a hosted image, which is fragile — it silently breaks if paths move in a future image. If the `-min` image ships lean enough, we can drop the cleanup entirely and rely on the image instead.

## What to look for
1. Do the jobs still provision? `-min` images carry fewer preinstalled toolsets, so the likely failure mode is a missing dependency (Maven, preinstalled JDKs for `JavaToolInstaller`, docker, Python) rather than disk.
2. The `Report disk space` step output — how much free space does `-min` actually start with?

If it provisions cleanly with comfortable headroom, the follow-up is to drop the cleanup steps for good. If it needs extra tool installs, we compare that cost against keeping the `rm -rf`.

## Scope
CI only, Linux only. Untouched: the Windows jobs, `java-version-check.yml`, and the official `run-e2e-tests-linux.yml` — those stay on `1es-ubuntu-22.04` until this experiment reports back.
